### PR TITLE
feat: Add self-contained launcher for easy installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Model Context Protocol (MCP) server that provides persistent context managemen
 Claude Code users often face context loss when the conversation window fills up. This MCP server solves that problem by providing a persistent memory layer for Claude AI. Whether you're working on complex refactoring, multi-file changes, or long debugging sessions, Memory Keeper ensures your Claude assistant remembers important context, decisions, and progress.
 
 ### Perfect for:
+
 - Long coding sessions with Claude Code
 - Complex projects requiring context preservation
 - Teams using Claude AI for collaborative development
@@ -19,7 +20,7 @@ Claude Code users often face context loss when the conversation window fills up.
 ## Features
 
 - 🔄 Save and restore context between Claude Code sessions
-- 📁 File content caching with change detection  
+- 📁 File content caching with change detection
 - 🏷️ Organize context with categories and priorities
 - 📺 **Channels** - Persistent topic-based organization (auto-derived from git branch)
 - 📸 Checkpoint system for complete context snapshots
@@ -38,7 +39,35 @@ Claude Code users often face context loss when the conversation window fills up.
 
 ## Installation
 
-### Method 1: From GitHub (Recommended)
+### Method 1: Self-Contained Launcher (Easiest)
+
+The launcher script handles everything automatically - installation, updates, and native module rebuilds:
+
+```bash
+# Quick install and add to Claude
+curl -fsSL https://raw.githubusercontent.com/mkreyman/mcp-memory-keeper/main/install.sh | bash
+
+# Then add to Claude (using the path shown by installer)
+claude mcp add memory-keeper "$HOME/.local/mcp-servers/memory-keeper/launcher.sh"
+```
+
+### Method 2: Direct from Repository
+
+If you've already cloned the repository:
+
+```bash
+# Add using the launcher script
+claude mcp add memory-keeper /path/to/mcp-memory-keeper/launcher.sh
+```
+
+The launcher automatically:
+
+- Installs memory-keeper if needed
+- Rebuilds native modules for your platform
+- Creates the data directory at `~/mcp-data/memory-keeper/`
+- Handles updates (if enabled with `MEMORY_KEEPER_AUTO_UPDATE=1`)
+
+### Method 3: Manual Installation
 
 ```bash
 # 1. Clone the repository
@@ -51,36 +80,19 @@ npm install
 # 3. Build the project
 npm run build
 
-# 4. Note the absolute path to the project
-pwd  # Copy this path for the configuration step
-```
-
-### Method 2: From Source
-
-```bash
-# 1. Download the source code
-# 2. Extract to a directory of your choice
-# 3. Navigate to the directory
-cd /path/to/mcp-memory-keeper
-
-# 4. Install and build
-npm install
-npm run build
+# 4. Add to Claude
+claude mcp add memory-keeper node /absolute/path/to/mcp-memory-keeper/dist/index.js
 ```
 
 ## Configuration
 
+### Environment Variables
+
+- `DATA_DIR` - Directory for database storage (default: `~/mcp-data/memory-keeper/`)
+- `MEMORY_KEEPER_INSTALL_DIR` - Installation directory (default: `~/.local/mcp-servers/memory-keeper/`)
+- `MEMORY_KEEPER_AUTO_UPDATE` - Set to `1` to enable auto-updates
+
 ### Claude Code (CLI)
-
-Open a terminal in your project directory and run:
-
-```bash
-# Add the Memory Keeper server
-claude mcp add memory-keeper node /absolute/path/to/mcp-memory-keeper/dist/index.js
-
-# Example for macOS:
-claude mcp add memory-keeper node /Users/username/projects/mcp-memory-keeper/dist/index.js
-```
 
 #### Configuration Scopes
 
@@ -128,6 +140,7 @@ claude mcp get memory-keeper
 **Important**: Replace `/absolute/path/to/mcp-memory-keeper` with the actual path where you cloned/installed the project.
 
 ### Example paths:
+
 - macOS: `/Users/username/projects/mcp-memory-keeper/dist/index.js`
 - Windows: `C:\\Users\\username\\projects\\mcp-memory-keeper\\dist\\index.js`
 - Linux: `/home/username/projects/mcp-memory-keeper/dist/index.js`
@@ -135,6 +148,7 @@ claude mcp get memory-keeper
 ### Verify Installation
 
 #### For Claude Code:
+
 1. Restart Claude Code or start a new session
 2. The Memory Keeper tools should be available automatically
 3. Test with: `mcp_memory_save({ key: "test", value: "Hello Memory Keeper!" })`
@@ -144,6 +158,7 @@ claude mcp get memory-keeper
    ```
 
 #### For Claude Desktop:
+
 1. Restart Claude Desktop after adding the configuration
 2. In a new conversation, the Memory Keeper tools should be available
 3. Test with the same command above
@@ -190,39 +205,39 @@ npm run build
 
 ```javascript
 // Start a new session
-mcp_context_session_start({ 
-  name: "Feature Development", 
-  description: "Working on user authentication" 
-})
+mcp_context_session_start({
+  name: 'Feature Development',
+  description: 'Working on user authentication',
+});
 
 // Start a session with project directory for git tracking
-mcp_context_session_start({ 
-  name: "Feature Development", 
-  description: "Working on user authentication",
-  projectDir: "/path/to/your/project"
-})
+mcp_context_session_start({
+  name: 'Feature Development',
+  description: 'Working on user authentication',
+  projectDir: '/path/to/your/project',
+});
 
 // Start a session with a default channel
-mcp_context_session_start({ 
-  name: "Feature Development", 
-  description: "Working on user authentication",
-  projectDir: "/path/to/your/project",
-  defaultChannel: "auth-feature"  // Will auto-derive from git branch if not specified
-})
+mcp_context_session_start({
+  name: 'Feature Development',
+  description: 'Working on user authentication',
+  projectDir: '/path/to/your/project',
+  defaultChannel: 'auth-feature', // Will auto-derive from git branch if not specified
+});
 
 // Set project directory for current session
-mcp_context_set_project_dir({ 
-  projectDir: "/path/to/your/project"
-})
+mcp_context_set_project_dir({
+  projectDir: '/path/to/your/project',
+});
 
 // List recent sessions
-mcp_context_session_list({ limit: 5 })
+mcp_context_session_list({ limit: 5 });
 
 // Continue from a previous session
-mcp_context_session_start({ 
-  name: "Feature Dev Continued",
-  continueFrom: "previous-session-id" 
-})
+mcp_context_session_start({
+  name: 'Feature Dev Continued',
+  continueFrom: 'previous-session-id',
+});
 ```
 
 ### Working with Channels (NEW in v0.10.0)
@@ -234,19 +249,19 @@ Channels provide persistent topic-based organization that survives session crash
 // Branch "feature/auth-system" becomes channel "feature-auth-system" (20 chars max)
 
 // Save to a specific channel
-mcp_context_save({ 
-  key: "auth_design", 
-  value: "Using JWT with refresh tokens",
-  category: "decision",
-  priority: "high",
-  channel: "auth-feature"  // Explicitly set channel
-})
+mcp_context_save({
+  key: 'auth_design',
+  value: 'Using JWT with refresh tokens',
+  category: 'decision',
+  priority: 'high',
+  channel: 'auth-feature', // Explicitly set channel
+});
 
 // Get items from a specific channel
-mcp_context_get({ channel: "auth-feature" })
+mcp_context_get({ channel: 'auth-feature' });
 
 // Get items across all channels (default behavior)
-mcp_context_get({ category: "task" })
+mcp_context_get({ category: 'task' });
 
 // Channels persist across sessions - perfect for:
 // - Multi-branch development
@@ -258,130 +273,130 @@ mcp_context_get({ category: "task" })
 
 ```javascript
 // Save with categories and priorities
-mcp_context_save({ 
-  key: "current_task", 
-  value: "Implement OAuth integration",
-  category: "task",
-  priority: "high"
-})
+mcp_context_save({
+  key: 'current_task',
+  value: 'Implement OAuth integration',
+  category: 'task',
+  priority: 'high',
+});
 
 // Save decisions
-mcp_context_save({ 
-  key: "auth_strategy", 
-  value: "Using JWT tokens with 24h expiry",
-  category: "decision",
-  priority: "high"
-})
+mcp_context_save({
+  key: 'auth_strategy',
+  value: 'Using JWT tokens with 24h expiry',
+  category: 'decision',
+  priority: 'high',
+});
 
 // Save progress notes
-mcp_context_save({ 
-  key: "progress_auth", 
-  value: "Completed user model, working on token generation",
-  category: "progress",
-  priority: "normal"
-})
+mcp_context_save({
+  key: 'progress_auth',
+  value: 'Completed user model, working on token generation',
+  category: 'progress',
+  priority: 'normal',
+});
 
 // Retrieve by category
-mcp_context_get({ category: "task" })
+mcp_context_get({ category: 'task' });
 
 // Retrieve specific item
-mcp_context_get({ key: "current_task" })
+mcp_context_get({ key: 'current_task' });
 
 // Get context from specific session
-mcp_context_get({ 
-  sessionId: "session-id-here",
-  category: "decision" 
-})
+mcp_context_get({
+  sessionId: 'session-id-here',
+  category: 'decision',
+});
 
 // Enhanced filtering (NEW in v0.10.0)
 mcp_context_get({
-  category: "task",
-  priorities: ["high", "normal"],
-  includeMetadata: true,      // Get timestamps, size info
-  sort: "created_desc",       // created_asc/desc, updated_asc/desc, priority
-  limit: 10,                  // Pagination
-  offset: 0
-})
+  category: 'task',
+  priorities: ['high', 'normal'],
+  includeMetadata: true, // Get timestamps, size info
+  sort: 'created_desc', // created_asc/desc, updated_asc/desc, priority
+  limit: 10, // Pagination
+  offset: 0,
+});
 
 // Time-based queries (NEW in v0.10.0)
 mcp_context_get({
-  createdAfter: "2025-01-20T00:00:00Z",
-  createdBefore: "2025-01-26T23:59:59Z",
-  includeMetadata: true
-})
+  createdAfter: '2025-01-20T00:00:00Z',
+  createdBefore: '2025-01-26T23:59:59Z',
+  includeMetadata: true,
+});
 
 // Pattern matching (NEW in v0.10.0)
 mcp_context_get({
-  keyPattern: "auth_.*",      // Regex to match keys
-  category: "decision"
-})
+  keyPattern: 'auth_.*', // Regex to match keys
+  category: 'decision',
+});
 ```
 
 ### File Caching
 
 ```javascript
 // Cache file content for change detection
-mcp_context_cache_file({ 
-  filePath: "/src/auth/user.model.ts",
-  content: fileContent 
-})
+mcp_context_cache_file({
+  filePath: '/src/auth/user.model.ts',
+  content: fileContent,
+});
 
 // Check if file has changed
-mcp_context_file_changed({ 
-  filePath: "/src/auth/user.model.ts",
-  currentContent: newFileContent 
-})
+mcp_context_file_changed({
+  filePath: '/src/auth/user.model.ts',
+  currentContent: newFileContent,
+});
 
 // Get current session status
-mcp_context_status()
+mcp_context_status();
 ```
 
 ### Complete Workflow Example
 
 ```javascript
 // 1. Start a new session
-mcp_context_session_start({ 
-  name: "Settings Refactor",
-  description: "Refactoring settings module for better performance" 
-})
+mcp_context_session_start({
+  name: 'Settings Refactor',
+  description: 'Refactoring settings module for better performance',
+});
 
 // 2. Save high-priority task
-mcp_context_save({ 
-  key: "main_task",
-  value: "Refactor Settings.Context to use behaviors",
-  category: "task",
-  priority: "high"
-})
+mcp_context_save({
+  key: 'main_task',
+  value: 'Refactor Settings.Context to use behaviors',
+  category: 'task',
+  priority: 'high',
+});
 
 // 3. Cache important files
-mcp_context_cache_file({ 
-  filePath: "lib/settings/context.ex",
-  content: originalFileContent 
-})
+mcp_context_cache_file({
+  filePath: 'lib/settings/context.ex',
+  content: originalFileContent,
+});
 
 // 4. Save decisions as you work
-mcp_context_save({ 
-  key: "architecture_decision",
-  value: "Split settings into read/write modules",
-  category: "decision",
-  priority: "high"
-})
+mcp_context_save({
+  key: 'architecture_decision',
+  value: 'Split settings into read/write modules',
+  category: 'decision',
+  priority: 'high',
+});
 
 // 5. Track progress
-mcp_context_save({ 
-  key: "progress_1",
-  value: "Completed behavior definition, 5 modules remaining",
-  category: "progress",
-  priority: "normal"
-})
+mcp_context_save({
+  key: 'progress_1',
+  value: 'Completed behavior definition, 5 modules remaining',
+  category: 'progress',
+  priority: 'normal',
+});
 
 // 6. Before context window fills up
-mcp_context_status()  // Check what's saved
+mcp_context_status(); // Check what's saved
 
 // 7. After Claude Code restart
-mcp_context_get({ category: "task", priority: "high" })  // Get high priority tasks
-mcp_context_get({ key: "architecture_decision" })       // Get specific decisions
-mcp_context_file_changed({ filePath: "lib/settings/context.ex" })  // Check for changes
+mcp_context_get({ category: 'task', priority: 'high' }); // Get high priority tasks
+mcp_context_get({ key: 'architecture_decision' }); // Get specific decisions
+mcp_context_file_changed({ filePath: 'lib/settings/context.ex' }); // Check for changes
 ```
 
 ### Checkpoints (Phase 2)
@@ -390,22 +405,22 @@ Create named snapshots of your entire context that can be restored later:
 
 ```javascript
 // Create a checkpoint before major changes
-mcp_context_checkpoint({ 
-  name: "before-refactor",
-  description: "State before major settings refactor",
-  includeFiles: true,      // Include cached files
-  includeGitStatus: true   // Capture git status
-})
+mcp_context_checkpoint({
+  name: 'before-refactor',
+  description: 'State before major settings refactor',
+  includeFiles: true, // Include cached files
+  includeGitStatus: true, // Capture git status
+});
 
 // Continue working...
 // If something goes wrong, restore from checkpoint
-mcp_context_restore_checkpoint({ 
-  name: "before-refactor",
-  restoreFiles: true  // Restore cached files too
-})
+mcp_context_restore_checkpoint({
+  name: 'before-refactor',
+  restoreFiles: true, // Restore cached files too
+});
 
 // Or restore the latest checkpoint
-mcp_context_restore_checkpoint({})
+mcp_context_restore_checkpoint({});
 ```
 
 ### Context Summarization (Phase 2)
@@ -414,34 +429,38 @@ Get AI-friendly summaries of your saved context:
 
 ```javascript
 // Get a summary of all context
-mcp_context_summarize()
+mcp_context_summarize();
 
 // Get summary of specific categories
-mcp_context_summarize({ 
-  categories: ["task", "decision"],
-  maxLength: 2000 
-})
+mcp_context_summarize({
+  categories: ['task', 'decision'],
+  maxLength: 2000,
+});
 
 // Summarize a specific session
-mcp_context_summarize({ 
-  sessionId: "session-id-here",
-  categories: ["progress"] 
-})
+mcp_context_summarize({
+  sessionId: 'session-id-here',
+  categories: ['progress'],
+});
 ```
 
 Example summary output:
+
 ```markdown
 # Context Summary
 
 ## High Priority Items
+
 - **main_task**: Refactor Settings.Context to use behaviors
 - **critical_bug**: Fix memory leak in subscription handler
 
 ## Task
+
 - implement_auth: Add OAuth2 authentication flow
 - update_tests: Update test suite for new API
 
 ## Decision
+
 - architecture_decision: Split settings into read/write modules
 - db_choice: Use PostgreSQL for better JSON support
 ```
@@ -454,26 +473,26 @@ Perform multiple operations atomically:
 // Save multiple items at once
 mcp_context_batch_save({
   items: [
-    { key: "config_api_url", value: "https://api.example.com", category: "note" },
-    { key: "config_timeout", value: "30000", category: "note" },
-    { key: "config_retries", value: "3", category: "note" }
-  ]
-})
+    { key: 'config_api_url', value: 'https://api.example.com', category: 'note' },
+    { key: 'config_timeout', value: '30000', category: 'note' },
+    { key: 'config_retries', value: '3', category: 'note' },
+  ],
+});
 
 // Update multiple items
 mcp_context_batch_update({
   updates: [
-    { key: "task_1", priority: "high" },
-    { key: "task_2", priority: "high" },
-    { key: "task_3", value: "Updated task description" }
-  ]
-})
+    { key: 'task_1', priority: 'high' },
+    { key: 'task_2', priority: 'high' },
+    { key: 'task_3', value: 'Updated task description' },
+  ],
+});
 
 // Delete by pattern
 mcp_context_batch_delete({
-  keyPattern: "temp_*",
-  dryRun: true  // Preview first
-})
+  keyPattern: 'temp_*',
+  dryRun: true, // Preview first
+});
 ```
 
 ### Channel Management
@@ -483,17 +502,17 @@ Reorganize context items between channels:
 ```javascript
 // Move items to a new channel
 mcp_context_reassign_channel({
-  keyPattern: "auth_*",
-  toChannel: "feature-authentication"
-})
+  keyPattern: 'auth_*',
+  toChannel: 'feature-authentication',
+});
 
 // Move from one channel to another
 mcp_context_reassign_channel({
-  fromChannel: "sprint-14",
-  toChannel: "sprint-15",
-  category: "task",
-  priorities: ["high"]
-})
+  fromChannel: 'sprint-14',
+  toChannel: 'sprint-15',
+  category: 'task',
+  priorities: ['high'],
+});
 ```
 
 ### Context Relationships
@@ -503,17 +522,17 @@ Build a graph of related items:
 ```javascript
 // Link related items
 mcp_context_link({
-  sourceKey: "epic_user_management",
-  targetKey: "task_create_user_api",
-  relationship: "contains"
-})
+  sourceKey: 'epic_user_management',
+  targetKey: 'task_create_user_api',
+  relationship: 'contains',
+});
 
 // Find related items
 mcp_context_get_related({
-  key: "epic_user_management",
-  relationship: "contains",
-  depth: 2
-})
+  key: 'epic_user_management',
+  relationship: 'contains',
+  depth: 2,
+});
 ```
 
 ### Real-time Monitoring
@@ -523,18 +542,18 @@ Watch for context changes:
 ```javascript
 // Create a watcher
 const watcher = await mcp_context_watch({
-  action: "create",
+  action: 'create',
   filters: {
-    categories: ["task"],
-    priorities: ["high"]
-  }
-})
+    categories: ['task'],
+    priorities: ['high'],
+  },
+});
 
 // Poll for changes
 const changes = await mcp_context_watch({
-  action: "poll",
-  watcherId: watcher.watcherId
-})
+  action: 'poll',
+  watcherId: watcher.watcherId,
+});
 ```
 
 ### Smart Compaction (Phase 3)
@@ -543,7 +562,7 @@ Never lose critical context when Claude's window fills up:
 
 ```javascript
 // Before context window fills
-mcp_context_prepare_compaction()
+mcp_context_prepare_compaction();
 
 // This automatically:
 // - Creates a checkpoint
@@ -560,15 +579,15 @@ Track git changes in your project directory and save context with commits:
 
 ```javascript
 // First, set your project directory (if not done during session start)
-mcp_context_set_project_dir({ 
-  projectDir: "/path/to/your/project"
-})
+mcp_context_set_project_dir({
+  projectDir: '/path/to/your/project',
+});
 
 // Commit with auto-save
-mcp_context_git_commit({ 
-  message: "feat: Add user authentication",
-  autoSave: true  // Creates checkpoint with commit
-})
+mcp_context_git_commit({
+  message: 'feat: Add user authentication',
+  autoSave: true, // Creates checkpoint with commit
+});
 
 // Context is automatically linked to the commit
 // Note: If no project directory is set, you'll see a helpful message
@@ -581,19 +600,19 @@ Find anything in your saved context:
 
 ```javascript
 // Search in keys and values
-mcp_context_search({ query: "authentication" })
+mcp_context_search({ query: 'authentication' });
 
 // Search only in keys
-mcp_context_search({ 
-  query: "config",
-  searchIn: ["key"] 
-})
+mcp_context_search({
+  query: 'config',
+  searchIn: ['key'],
+});
 
 // Search in specific session
-mcp_context_search({ 
-  query: "bug",
-  sessionId: "session-id" 
-})
+mcp_context_search({
+  query: 'bug',
+  sessionId: 'session-id',
+});
 ```
 
 ### Export/Import (Phase 3)
@@ -602,24 +621,24 @@ Share context or backup your work:
 
 ```javascript
 // Export current session
-mcp_context_export()  // Creates memory-keeper-export-xxx.json
+mcp_context_export(); // Creates memory-keeper-export-xxx.json
 
 // Export specific session
-mcp_context_export({ 
-  sessionId: "session-id",
-  format: "json" 
-})
+mcp_context_export({
+  sessionId: 'session-id',
+  format: 'json',
+});
 
 // Import from file
-mcp_context_import({ 
-  filePath: "memory-keeper-export-xxx.json" 
-})
+mcp_context_import({
+  filePath: 'memory-keeper-export-xxx.json',
+});
 
 // Merge into current session
-mcp_context_import({ 
-  filePath: "backup.json",
-  merge: true 
-})
+mcp_context_import({
+  filePath: 'backup.json',
+  merge: true,
+});
 ```
 
 ### Knowledge Graph (Phase 4)
@@ -628,33 +647,33 @@ Automatically extract entities and relationships from your context:
 
 ```javascript
 // Analyze context to build knowledge graph
-mcp_context_analyze()
+mcp_context_analyze();
 
 // Or analyze specific categories
-mcp_context_analyze({ 
-  categories: ["task", "decision"] 
-})
+mcp_context_analyze({
+  categories: ['task', 'decision'],
+});
 
 // Find related entities
-mcp_context_find_related({ 
-  key: "AuthService",
-  maxDepth: 2 
-})
+mcp_context_find_related({
+  key: 'AuthService',
+  maxDepth: 2,
+});
 
 // Generate visualization data
-mcp_context_visualize({ 
-  type: "graph" 
-})
+mcp_context_visualize({
+  type: 'graph',
+});
 
 // Timeline view
-mcp_context_visualize({ 
-  type: "timeline" 
-})
+mcp_context_visualize({
+  type: 'timeline',
+});
 
 // Category/priority heatmap
-mcp_context_visualize({ 
-  type: "heatmap" 
-})
+mcp_context_visualize({
+  type: 'heatmap',
+});
 ```
 
 ### Semantic Search (Phase 4.2)
@@ -663,23 +682,23 @@ Find context using natural language queries:
 
 ```javascript
 // Search with natural language
-mcp_context_semantic_search({ 
-  query: "how are we handling user authentication?",
-  topK: 5 
-})
+mcp_context_semantic_search({
+  query: 'how are we handling user authentication?',
+  topK: 5,
+});
 
 // Find the most relevant security decisions
-mcp_context_semantic_search({ 
-  query: "security concerns and decisions",
-  minSimilarity: 0.5 
-})
+mcp_context_semantic_search({
+  query: 'security concerns and decisions',
+  minSimilarity: 0.5,
+});
 
 // Search with specific similarity threshold
-mcp_context_semantic_search({ 
-  query: "database performance optimization",
+mcp_context_semantic_search({
+  query: 'database performance optimization',
   topK: 10,
-  minSimilarity: 0.3 
-})
+  minSimilarity: 0.3,
+});
 ```
 
 ### Multi-Agent System (Phase 4.3)
@@ -689,60 +708,58 @@ Delegate complex analysis tasks to specialized agents:
 ```javascript
 // Analyze patterns in your context
 mcp_context_delegate({
-  taskType: "analyze",
+  taskType: 'analyze',
   input: {
-    analysisType: "patterns",
-    categories: ["task", "decision"]
-  }
-})
+    analysisType: 'patterns',
+    categories: ['task', 'decision'],
+  },
+});
 
 // Get comprehensive analysis
 mcp_context_delegate({
-  taskType: "analyze", 
+  taskType: 'analyze',
   input: {
-    analysisType: "comprehensive"
-  }
-})
+    analysisType: 'comprehensive',
+  },
+});
 
 // Analyze relationships between entities
 mcp_context_delegate({
-  taskType: "analyze",
+  taskType: 'analyze',
   input: {
-    analysisType: "relationships",
-    maxDepth: 3
-  }
-})
+    analysisType: 'relationships',
+    maxDepth: 3,
+  },
+});
 
 // Create intelligent summaries
 mcp_context_delegate({
-  taskType: "synthesize",
+  taskType: 'synthesize',
   input: {
-    synthesisType: "summary",
-    maxLength: 1000
-  }
-})
+    synthesisType: 'summary',
+    maxLength: 1000,
+  },
+});
 
 // Get actionable recommendations
 mcp_context_delegate({
-  taskType: "synthesize",
+  taskType: 'synthesize',
   input: {
-    synthesisType: "recommendations",
-    analysisResults: {} // Can pass previous analysis results
-  }
-})
+    synthesisType: 'recommendations',
+    analysisResults: {}, // Can pass previous analysis results
+  },
+});
 
 // Chain multiple agent tasks
 mcp_context_delegate({
   chain: true,
-  taskType: ["analyze", "synthesize"],
-  input: [
-    { analysisType: "comprehensive" },
-    { synthesisType: "recommendations" }
-  ]
-})
+  taskType: ['analyze', 'synthesize'],
+  input: [{ analysisType: 'comprehensive' }, { synthesisType: 'recommendations' }],
+});
 ```
 
 Agent Types:
+
 - **Analyzer Agent**: Detects patterns, analyzes relationships, tracks trends
 - **Synthesizer Agent**: Creates summaries, merges insights, generates recommendations
 
@@ -753,21 +770,21 @@ Explore alternatives without losing your original work:
 ```javascript
 // Create a branch to try something new
 mcp_context_branch_session({
-  branchName: "experimental-refactor",
-  copyDepth: "shallow" // Only copy high-priority items
-})
+  branchName: 'experimental-refactor',
+  copyDepth: 'shallow', // Only copy high-priority items
+});
 
 // Or create a full copy
 mcp_context_branch_session({
-  branchName: "feature-complete-copy",
-  copyDepth: "deep" // Copy everything
-})
+  branchName: 'feature-complete-copy',
+  copyDepth: 'deep', // Copy everything
+});
 
 // Later, merge changes back
 mcp_context_merge_sessions({
-  sourceSessionId: "branch-session-id",
-  conflictResolution: "keep_newest" // or "keep_current", "keep_source"
-})
+  sourceSessionId: 'branch-session-id',
+  conflictResolution: 'keep_newest', // or "keep_current", "keep_source"
+});
 ```
 
 ### Journal Entries (Phase 4.4)
@@ -777,15 +794,15 @@ Track your thoughts and progress with timestamped journal entries:
 ```javascript
 // Add a journal entry
 mcp_context_journal_entry({
-  entry: "Completed the authentication module. Tests are passing!",
-  tags: ["milestone", "authentication"],
-  mood: "accomplished"
-})
+  entry: 'Completed the authentication module. Tests are passing!',
+  tags: ['milestone', 'authentication'],
+  mood: 'accomplished',
+});
 
 // Entries are included in timeline views
 mcp_context_timeline({
-  groupBy: "day"
-})
+  groupBy: 'day',
+});
 ```
 
 ### Timeline & Activity Tracking (Phase 4.4)
@@ -795,19 +812,19 @@ Visualize your work patterns over time:
 ```javascript
 // Get activity timeline
 mcp_context_timeline({
-  startDate: "2024-01-01",
-  endDate: "2024-01-31",
-  groupBy: "day" // or "hour", "week"
-})
+  startDate: '2024-01-01',
+  endDate: '2024-01-31',
+  groupBy: 'day', // or "hour", "week"
+});
 
 // Enhanced timeline (NEW in v0.10.0)
 mcp_context_timeline({
-  groupBy: "hour",
-  includeItems: true,         // Show actual items, not just counts
-  categories: ["task", "progress"],  // Filter by categories
-  relativeTime: true,         // Show "2 hours ago" format
-  itemsPerPeriod: 10         // Limit items shown per time period
-})
+  groupBy: 'hour',
+  includeItems: true, // Show actual items, not just counts
+  categories: ['task', 'progress'], // Filter by categories
+  relativeTime: true, // Show "2 hours ago" format
+  itemsPerPeriod: 10, // Limit items shown per time period
+});
 
 // Shows:
 // - Context items created per day/hour
@@ -823,10 +840,10 @@ Save space by intelligently compressing old context:
 ```javascript
 // Compress items older than 30 days
 mcp_context_compress({
-  olderThan: "2024-01-01",
-  preserveCategories: ["decision", "critical"], // Keep these
-  targetSize: 1000 // Target size in KB (optional)
-})
+  olderThan: '2024-01-01',
+  preserveCategories: ['decision', 'critical'], // Keep these
+  targetSize: 1000, // Target size in KB (optional)
+});
 
 // Compression summary shows:
 // - Items compressed
@@ -842,14 +859,14 @@ Track events from other MCP tools:
 ```javascript
 // Record events from other tools
 mcp_context_integrate_tool({
-  toolName: "code-analyzer",
-  eventType: "security-scan-complete",
+  toolName: 'code-analyzer',
+  eventType: 'security-scan-complete',
   data: {
     vulnerabilities: 0,
     filesScanned: 150,
-    important: true // Creates high-priority context item
-  }
-})
+    important: true, // Creates high-priority context item
+  },
+});
 ```
 
 ## Documentation
@@ -929,28 +946,30 @@ npm test -- summarization.test.ts
 ```
 
 Test categories:
+
 - **Unit Tests**: Input validation, database operations, git integration
 - **Integration Tests**: Full tool workflows, error scenarios, edge cases
 - **Coverage**: 97%+ coverage on critical modules
 
 ## Feature Status
 
-| Feature | Maturity | Version | Use Case |
-|---------|----------|---------|----------|
-| Basic Save/Get | ✅ Stable | v0.1+ | Daily context management |
-| Sessions | ✅ Stable | v0.2+ | Multi-project work |
-| File Caching | ✅ Stable | v0.2+ | Track file changes |
-| Checkpoints | ✅ Stable | v0.3+ | Context preservation |
-| Smart Compaction | ✅ Stable | v0.3+ | Pre-compaction prep |
-| Git Integration | ✅ Stable | v0.3+ | Commit context tracking |
-| Search | ✅ Stable | v0.3+ | Find saved items |
-| Export/Import | ✅ Stable | v0.3+ | Backup & sharing |
-| Knowledge Graph | ✅ Stable | v0.5+ | Code relationship analysis |
-| Visualization | ✅ Stable | v0.5+ | Context exploration |
-| Semantic Search | ✅ Stable | v0.6+ | Natural language queries |
-| Multi-Agent | ✅ Stable | v0.7+ | Intelligent processing |
+| Feature          | Maturity  | Version | Use Case                   |
+| ---------------- | --------- | ------- | -------------------------- |
+| Basic Save/Get   | ✅ Stable | v0.1+   | Daily context management   |
+| Sessions         | ✅ Stable | v0.2+   | Multi-project work         |
+| File Caching     | ✅ Stable | v0.2+   | Track file changes         |
+| Checkpoints      | ✅ Stable | v0.3+   | Context preservation       |
+| Smart Compaction | ✅ Stable | v0.3+   | Pre-compaction prep        |
+| Git Integration  | ✅ Stable | v0.3+   | Commit context tracking    |
+| Search           | ✅ Stable | v0.3+   | Find saved items           |
+| Export/Import    | ✅ Stable | v0.3+   | Backup & sharing           |
+| Knowledge Graph  | ✅ Stable | v0.5+   | Code relationship analysis |
+| Visualization    | ✅ Stable | v0.5+   | Context exploration        |
+| Semantic Search  | ✅ Stable | v0.6+   | Natural language queries   |
+| Multi-Agent      | ✅ Stable | v0.7+   | Intelligent processing     |
 
 ### Current Features (v0.10.0)
+
 - ✅ **Session Management**: Create, list, and continue sessions with branching support
 - ✅ **Channels**: Persistent topic-based organization (auto-derived from git branch)
 - ✅ **Context Storage**: Save/retrieve context with categories (task, decision, progress, note) and priorities
@@ -976,18 +995,21 @@ Test categories:
 ### Roadmap
 
 #### Phase 4: Advanced Features (In Development)
+
 - 🚧 **Knowledge Graph**: Entity-relation tracking for code understanding
 - 🚧 **Vector Search**: Semantic search using natural language
 - 📋 **Multi-Agent Processing**: Intelligent analysis and synthesis
 - 📋 **Time-Aware Context**: Timeline views and journal entries
 
 #### Phase 5: Documentation & Polish
+
 - ✅ **Examples**: Comprehensive quick-start scenarios
 - ✅ **Troubleshooting**: Common issues and solutions
 - 🚧 **Recipes**: Common patterns and workflows
 - 📋 **Video Tutorials**: Visual guides for key features
 
 #### Future Enhancements
+
 - [ ] Web UI for browsing context history
 - [ ] Multi-user/team collaboration features
 - [ ] Cloud sync and sharing
@@ -1023,6 +1045,7 @@ Mark Kreyman
 ## Support
 
 If you encounter any issues or have questions:
+
 - Open an issue on [GitHub](https://github.com/mkreyman/mcp-memory-keeper/issues)
 - Check the [MCP documentation](https://modelcontextprotocol.io/)
 - Join the Claude Code community discussions

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Quick installer for memory-keeper MCP server
+# Can be run directly from GitHub raw URL
+
+set -e
+
+INSTALL_DIR="${MEMORY_KEEPER_INSTALL_DIR:-$HOME/.local/mcp-servers/memory-keeper}"
+REPO_URL="https://github.com/mkreyman/mcp-memory-keeper.git"
+
+echo "Installing memory-keeper MCP server..."
+
+# Create installation directory
+mkdir -p "$INSTALL_DIR"
+
+# Clone repository
+if [ -d "$INSTALL_DIR/.git" ]; then
+    echo "Updating existing installation..."
+    cd "$INSTALL_DIR"
+    git pull
+else
+    echo "Cloning memory-keeper..."
+    git clone "$REPO_URL" "$INSTALL_DIR"
+    cd "$INSTALL_DIR"
+fi
+
+# Make launcher executable
+chmod +x "$INSTALL_DIR/launcher.sh"
+
+echo ""
+echo "✅ Memory-keeper installed successfully!"
+echo ""
+echo "To add to Claude, run:"
+echo "claude mcp add memory-keeper \"$INSTALL_DIR/launcher.sh\""
+echo ""
+echo "Data directory: ~/mcp-data/memory-keeper/"

--- a/launcher.sh
+++ b/launcher.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Self-contained memory-keeper launcher that handles installation and updates
+# This script can be used directly with Claude MCP configuration
+
+# Configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${MEMORY_KEEPER_INSTALL_DIR:-$HOME/.local/mcp-servers/memory-keeper}"
+DATA_DIR="${DATA_DIR:-$HOME/mcp-data/memory-keeper}"
+REPO_URL="https://github.com/mkreyman/mcp-memory-keeper.git"
+
+# If running from a cloned repo, use that instead of installing
+if [ -f "$SCRIPT_DIR/package.json" ] && [ -d "$SCRIPT_DIR/.git" ]; then
+    INSTALL_DIR="$SCRIPT_DIR"
+    echo "Using local repository at $INSTALL_DIR" >&2
+else
+    # Ensure installation directory exists
+    mkdir -p "$INSTALL_DIR"
+    
+    # Check if memory-keeper is installed
+    if [ ! -d "$INSTALL_DIR/.git" ]; then
+        echo "First time setup: Installing memory-keeper..." >&2
+        cd "$INSTALL_DIR"
+        git clone "$REPO_URL" . >&2
+        npm install >&2
+        npm run build >&2
+        echo "Memory-keeper installation complete!" >&2
+    fi
+fi
+
+# Ensure data directory exists
+mkdir -p "$DATA_DIR"
+
+# Check if we need to rebuild (e.g., after switching between environments)
+BUILD_MARKER="$INSTALL_DIR/.build-marker-$(uname -s)-$(uname -m)"
+if [ ! -f "$BUILD_MARKER" ]; then
+    echo "Rebuilding native modules for $(uname -s) $(uname -m)..." >&2
+    cd "$INSTALL_DIR"
+    npm rebuild better-sqlite3 >&2
+    touch "$BUILD_MARKER"
+    # Clean up old build markers
+    find "$INSTALL_DIR" -name ".build-marker-*" ! -name "$(basename "$BUILD_MARKER")" -delete 2>/dev/null
+    echo "Native modules rebuilt!" >&2
+fi
+
+# Ensure the project is built
+if [ ! -d "$INSTALL_DIR/dist" ]; then
+    echo "Building memory-keeper..." >&2
+    cd "$INSTALL_DIR"
+    npm run build >&2
+fi
+
+# Optional: Check for updates (set MEMORY_KEEPER_AUTO_UPDATE=1 to enable)
+if [ "${MEMORY_KEEPER_AUTO_UPDATE}" = "1" ] && [ -d "$INSTALL_DIR/.git" ]; then
+    echo "Checking for updates..." >&2
+    cd "$INSTALL_DIR"
+    git pull >&2
+    npm install >&2
+    npm run build >&2
+fi
+
+# Change to data directory and run
+cd "$DATA_DIR"
+exec node "$INSTALL_DIR/dist/index.js" "$@"


### PR DESCRIPTION
## Summary
- Add launcher.sh for self-contained memory-keeper installation and execution
- Add install.sh for quick one-line installation from GitHub
- Update documentation with new installation methods

## Details

This PR adds a self-contained launcher that makes memory-keeper installation as simple as:
```bash
curl -fsSL https://raw.githubusercontent.com/mkreyman/mcp-memory-keeper/main/install.sh  < /dev/null |  bash
claude mcp add memory-keeper "$HOME/.local/mcp-servers/memory-keeper/launcher.sh"
```

### Features of launcher.sh:
- Automatically installs memory-keeper if not present
- Rebuilds native modules for the current platform (macOS/Linux)
- Detects if running from a cloned repo and uses that instead
- Creates data directory at ~/mcp-data/memory-keeper/
- Supports environment variables for customization
- Uses build markers to avoid unnecessary rebuilds
- Optional auto-update support

### Benefits:
- No more native module conflicts between macOS and Linux
- Users don't need to understand npm or build processes
- Easy sharing - just point to the launcher script
- Works for both development and end users

## Test plan
- [x] Test launcher.sh from cloned repository
- [x] Test launcher.sh auto-installation to ~/.local/mcp-servers
- [x] Test with Claude MCP configuration
- [x] Verify native module rebuilding works
- [ ] Test install.sh one-liner (after merge)

🤖 Generated with [Claude Code](https://claude.ai/code)