### PR TITLE
fix: Add npm install and build to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,6 +23,12 @@ else
     cd "$INSTALL_DIR"
 fi
 
+# Install dependencies and build
+echo "Installing dependencies..."
+npm install
+echo "Building memory-keeper..."
+npm run build
+
 # Make launcher executable
 chmod +x "$INSTALL_DIR/launcher.sh"
 


### PR DESCRIPTION
## Summary
The install script was missing npm install and build steps, causing the launcher to fail on fresh installations.

## Problem
When running the one-liner installation:
```bash
curl -fsSL https://raw.githubusercontent.com/mkreyman/mcp-memory-keeper/main/install.sh  < /dev/null |  bash
```

The script would clone the repository but not install dependencies or build the project. This caused the launcher to fail with "tsc: command not found" when trying to build.

## Solution
Added npm install and npm run build steps to the install script after cloning/updating the repository.

## Test Results
Tested the complete flow:
1. Fresh installation works correctly
2. Dependencies are installed
3. Project is built
4. Launcher executes successfully
5. Can be added to Claude MCP configuration

🤖 Generated with [Claude Code](https://claude.ai/code)