### PR TITLE
feat: restore checkpoints on context_import round trip (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-05
+
 ### Added
 
 - **Checkpoints now survive an export → import round trip** (#37, follow-up to #36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Checkpoints now survive an export → import round trip** (#37, follow-up to #36)
+  - `context_export` writes a new `0.5.0` format that includes the `checkpointItems` and `checkpointFiles` join rows (previously only the bare `checkpoints` rows were exported, which made imported checkpoints empty/useless).
+  - `context_import` restores checkpoints and rewires their links: each checkpoint gets a fresh id, and its item/file links are remapped onto the freshly-imported context-item and file-cache ids. Links pointing at a skipped or absent row are dropped rather than aborting the import. The whole restore happens inside the existing atomic transaction.
+  - The import summary now reports `Checkpoints: N (skipped M malformed), links restored: K`.
+  - **Backward compatible:** importing a pre-`0.5.0` export (no join-row arrays) does not error and reports `Checkpoints in file: N (not imported — re-export with v0.5.0+ to include them)`, preserving the prior explicit-not-imported behaviour.
+  - The entry-count cap from #36 now also bounds checkpoint and join-row arrays.
+
 ## [0.13.0] - 2026-06-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `context_export` writes a new `0.5.0` format that includes the `checkpointItems` and `checkpointFiles` join rows (previously only the bare `checkpoints` rows were exported, which made imported checkpoints empty/useless).
   - `context_import` restores checkpoints and rewires their links: each checkpoint gets a fresh id, and its item/file links are remapped onto the freshly-imported context-item and file-cache ids. Links pointing at a skipped or absent row are dropped rather than aborting the import. The whole restore happens inside the existing atomic transaction.
   - The import summary now reports `Checkpoints: N (skipped M malformed), links restored: K`.
-  - **Backward compatible:** importing a pre-`0.5.0` export (no join-row arrays) does not error and reports `Checkpoints in file: N (not imported — re-export with v0.5.0+ to include them)`, preserving the prior explicit-not-imported behaviour.
+  - **Backward compatible:** importing a pre-`0.5.0` export (no join-row arrays) does not error and reports the checkpoints as not imported, preserving the prior explicit-not-imported behaviour.
   - The entry-count cap from #36 now also bounds checkpoint and join-row arrays.
+  - **Merge safety:** on a key/path collision during `merge` import, the existing row is now UPDATED in place (its id preserved) instead of `INSERT OR REPLACE`, so a pre-existing checkpoint's links to that row are no longer cascade-deleted. Both `context_items` and `file_cache` (which have UNIQUE constraints) are handled this way.
+  - **Fidelity & observability:** `file_cache.size` is restored on import; duplicate-key/path rows that collapse during import are reported (`collapsed N duplicate-key`); dropped dangling checkpoint links are surfaced (`links restored: K (dropped N dangling)`); and `metadata.totalSize` now accounts for the checkpoint join arrays.
 
 ## [0.13.0] - 2026-06-05
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-memory-keeper",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-memory-keeper",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-memory-keeper",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for persistent context management in AI coding assistants",
   "main": "dist/index.js",
   "bin": {

--- a/src/__tests__/e2e/checkpoint-round-trip.test.ts
+++ b/src/__tests__/e2e/checkpoint-round-trip.test.ts
@@ -45,37 +45,41 @@ async function startServer(): Promise<Client> {
     (global as any).testProcesses.push(proc);
   }
 
+  // A single persistent reader dispatches each response to its pending request
+  // by id, so concurrent calls cannot share/consume each other's buffer.
+  const pending = new Map<number, { resolve: (v: any) => void; timer: NodeJS.Timeout }>();
   let buffer = '';
   let nextId = 0;
 
-  const send = (method: string, params: Record<string, unknown>, id?: number): Promise<any> =>
+  proc.stdout?.on('data', (data: Buffer) => {
+    buffer += data.toString();
+    const lines = buffer.split('\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let msg: any;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (msg.id != null && pending.has(msg.id)) {
+        const p = pending.get(msg.id)!;
+        clearTimeout(p.timer);
+        pending.delete(msg.id);
+        p.resolve(msg);
+      }
+    }
+  });
+
+  const send = (method: string, params: Record<string, unknown>): Promise<any> =>
     new Promise((resolve, reject) => {
-      const reqId = id ?? ++nextId;
-      const timeout = setTimeout(() => {
-        proc.stdout?.removeListener('data', onData);
+      const reqId = ++nextId;
+      const timer = setTimeout(() => {
+        pending.delete(reqId);
         reject(new Error(`Timeout waiting for ${method} (id=${reqId})`));
       }, 5000);
-
-      const onData = (data: Buffer) => {
-        buffer += data.toString();
-        const lines = buffer.split('\n');
-        buffer = lines.pop() || '';
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          try {
-            const msg = JSON.parse(line);
-            if (msg.id === reqId) {
-              clearTimeout(timeout);
-              proc.stdout?.removeListener('data', onData);
-              resolve(msg);
-            }
-          } catch {
-            // not JSON for us
-          }
-        }
-      };
-
-      proc.stdout?.on('data', onData);
+      pending.set(reqId, { resolve, timer });
       proc.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params, id: reqId }) + '\n');
     });
 
@@ -94,6 +98,8 @@ async function startServer(): Promise<Client> {
   };
 
   const close = async (): Promise<void> => {
+    for (const p of pending.values()) clearTimeout(p.timer);
+    pending.clear();
     if (!proc.killed) {
       proc.kill('SIGTERM');
       await new Promise<void>(resolve => {
@@ -153,7 +159,7 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
       includeGitStatus: false,
     });
     expect(cpText).toMatch(/Created checkpoint/i);
-    expect(cpText).toMatch(/Context items:\s*2/);
+    expect(cpText).toMatch(/Context items:\s*2\b/);
 
     const exportText = await server.call('context_export', { confirmEmpty: true });
     const exportPath = parseExportPath(exportText);
@@ -169,7 +175,7 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
 
       const importText = await importer.call('context_import', { filePath: 'incoming.json' });
       expect(importText).toMatch(/Import successful/i);
-      expect(importText).toMatch(/Context items:\s*2/);
+      expect(importText).toMatch(/Context items:\s*2\b/);
       // 2 item links + 1 file link = 3, none dropped.
       expect(importText).toMatch(/Checkpoints:\s*1, links restored:\s*3$/m);
 
@@ -181,8 +187,8 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
         restoreFiles: true,
       });
       expect(restoreText).toMatch(/Successfully restored from checkpoint/i);
-      expect(restoreText).toMatch(/Context items:\s*2/);
-      expect(restoreText).toMatch(/Files:\s*1/);
+      expect(restoreText).toMatch(/Context items:\s*2\b/);
+      expect(restoreText).toMatch(/Files:\s*1\b/);
     } finally {
       await importer.close();
     }
@@ -205,7 +211,7 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
     try {
       const text = await server.call('context_import', { filePath: 'legacy-export.json' });
       expect(text).toMatch(/Import successful/i);
-      expect(text).toMatch(/Context items:\s*1/);
+      expect(text).toMatch(/Context items:\s*1\b/);
       expect(text).toMatch(/Checkpoints in file:\s*1 \(not imported/i);
     } finally {
       fs.rmSync(legacy, { force: true });
@@ -244,9 +250,56 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
         name: 'partial-cp',
         restoreFiles: true,
       });
-      expect(restoreText).toMatch(/Context items:\s*1/); // not 2 — dangling link was dropped
+      expect(restoreText).toMatch(/Context items:\s*1\b/); // not 2 — dangling link was dropped
     } finally {
       fs.rmSync(partial, { force: true });
+    }
+  });
+
+  it('merge import updates a colliding item in place and preserves a pre-existing checkpoint link', async () => {
+    // Regression guard: a merge import whose item key collides with an existing
+    // row must UPDATE in place (preserving the row id) rather than INSERT OR
+    // REPLACE. REPLACE would cascade-delete the existing checkpoint's link.
+    await server.call('context_session_start', { name: 'merge-target' });
+    await server.call('context_save', { key: 'shared_key', value: 'original', category: 'task' });
+    const cp = await server.call('context_checkpoint', {
+      name: 'pre-merge-cp',
+      includeFiles: false,
+      includeGitStatus: false,
+    });
+    expect(cp).toMatch(/Context items:\s*1\b/);
+
+    const mergeFile = path.join(server.exportsDir, 'merge-in.json');
+    fs.mkdirSync(server.exportsDir, { recursive: true });
+    fs.writeFileSync(
+      mergeFile,
+      JSON.stringify({
+        version: '0.5.0',
+        session: { name: 'incoming', branch: 'main' },
+        contextItems: [{ id: 'x', key: 'shared_key', value: 'updated' }],
+        fileCache: [],
+        checkpoints: [],
+        checkpointItems: [],
+        checkpointFiles: [],
+      })
+    );
+    try {
+      const imp = await server.call('context_import', { filePath: 'merge-in.json', merge: true });
+      expect(imp).toMatch(/Mode:\s*Merged/);
+
+      // The colliding item was updated in place (value changed).
+      const got = await server.call('context_get', { key: 'shared_key' });
+      expect(got).toContain('updated');
+
+      // The pre-existing checkpoint still restores its 1 item — the link
+      // survived because the row id was preserved (no REPLACE-cascade).
+      const restore = await server.call('context_restore_checkpoint', {
+        name: 'pre-merge-cp',
+        restoreFiles: false,
+      });
+      expect(restore).toMatch(/Context items:\s*1\b/);
+    } finally {
+      fs.rmSync(mergeFile, { force: true });
     }
   });
 });

--- a/src/__tests__/e2e/checkpoint-round-trip.test.ts
+++ b/src/__tests__/e2e/checkpoint-round-trip.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { spawn, ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * E2E tests for GitHub issue #37: checkpoints (and their checkpoint_items /
+ * checkpoint_files join rows) must survive a context_export -> context_import
+ * round trip.
+ *
+ * Before the fix, exports carried the `checkpoints` rows but not the join rows,
+ * and import restored neither — so a re-imported session lost its checkpoints.
+ * The 0.5.0 export format adds `checkpointItems` / `checkpointFiles`, and import
+ * rewires their foreign keys onto the freshly-generated ids.
+ *
+ * @see https://github.com/mkreyman/mcp-memory-keeper/issues/37
+ */
+
+let serverProcess: ChildProcess | null = null;
+let tempDir: string;
+let exportsDir: string;
+let msgId = 0;
+let outputBuffer = '';
+
+function sendRequest(
+  method: string,
+  params: Record<string, unknown> = {},
+  timeoutMs = 5000
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const id = ++msgId;
+    const timeout = setTimeout(() => {
+      reject(new Error(`Timeout waiting for response to ${method} (id=${id})`));
+    }, timeoutMs);
+
+    const onData = (data: Buffer) => {
+      outputBuffer += data.toString();
+      const lines = outputBuffer.split('\n');
+      outputBuffer = lines.pop() || '';
+
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg = JSON.parse(line);
+          if (msg.id === id) {
+            clearTimeout(timeout);
+            serverProcess?.stdout?.removeListener('data', onData);
+            resolve(msg);
+          }
+        } catch {
+          // Not JSON, skip
+        }
+      }
+    };
+
+    serverProcess?.stdout?.on('data', onData);
+    serverProcess?.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params, id }) + '\n');
+  });
+}
+
+function callTool(name: string, args: Record<string, unknown>): Promise<string> {
+  return sendRequest('tools/call', { name, arguments: args }).then(
+    res => res.result?.content?.[0]?.text ?? JSON.stringify(res)
+  );
+}
+
+/** Pull the export file path out of a context_export success message. */
+function parseExportPath(exportText: string): string {
+  const match = exportText.match(/to:\s*(.+?\.json)/);
+  if (!match) throw new Error(`Could not parse export path from: ${exportText}`);
+  return match[1];
+}
+
+describe('E2E: checkpoint export/import round trip (issue #37)', () => {
+  beforeAll(async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-checkpoint-'));
+    exportsDir = path.join(tempDir, 'exports');
+
+    serverProcess = spawn('node', [path.join(__dirname, '../../../dist/index.js')], {
+      env: { ...process.env, DATA_DIR: tempDir },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    if ((global as any).testProcesses) {
+      (global as any).testProcesses.push(serverProcess);
+    }
+
+    const initResponse = await sendRequest('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'checkpoint-e2e', version: '1.0.0' },
+    });
+    expect(initResponse.result).toHaveProperty('protocolVersion');
+
+    serverProcess?.stdin?.write(
+      JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n'
+    );
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }, 10000);
+
+  afterAll(async () => {
+    if (serverProcess && !serverProcess.killed) {
+      serverProcess.kill('SIGTERM');
+      await new Promise<void>(resolve => {
+        const timeout = setTimeout(() => {
+          serverProcess?.kill('SIGKILL');
+          resolve();
+        }, 3000);
+        serverProcess?.on('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      serverProcess?.removeAllListeners();
+    }
+    serverProcess = null;
+
+    try {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('restores a checkpoint and its linked items + files through export -> import', async () => {
+    // Seed two items and a cached file in a fresh session.
+    await callTool('context_session_start', { name: 'cp-source' });
+    await callTool('context_save', { key: 'cp_item_a', value: 'value_a', category: 'task' });
+    await callTool('context_save', { key: 'cp_item_b', value: 'value_b', category: 'note' });
+    await callTool('context_cache_file', {
+      filePath: '/tmp/checkpoint-test.ts',
+      content: 'cached file content',
+    });
+
+    // Capture a checkpoint that links both items and the file.
+    const cpText = await callTool('context_checkpoint', {
+      name: 'cp-roundtrip',
+      description: 'round trip checkpoint',
+      includeFiles: true,
+      includeGitStatus: false,
+    });
+    expect(cpText).toMatch(/Created checkpoint/i);
+    expect(cpText).toMatch(/Context items:\s*2/);
+
+    // Export, then import the produced file into a new session.
+    const exportText = await callTool('context_export', { confirmEmpty: true });
+    const exportPath = parseExportPath(exportText);
+    expect(exportPath.startsWith(exportsDir)).toBe(true);
+
+    const importText = await callTool('context_import', { filePath: exportPath });
+    expect(importText).toMatch(/Import successful/i);
+    // The imported checkpoint must be restored with its links rewired: 2 item
+    // links + 1 file link = 3.
+    expect(importText).toMatch(/Checkpoints:\s*1.*links restored:\s*3/);
+
+    // End-to-end proof: restoring the checkpoint by name reproduces its items
+    // and file (the join rows point at the freshly-imported rows).
+    const restoreText = await callTool('context_restore_checkpoint', {
+      name: 'cp-roundtrip',
+      restoreFiles: true,
+    });
+    expect(restoreText).toMatch(/Successfully restored from checkpoint/i);
+    expect(restoreText).toMatch(/Context items:\s*2/);
+    expect(restoreText).toMatch(/Files:\s*1/);
+  });
+
+  it('reports legacy exports (no checkpointItems) as not imported, without error', async () => {
+    // A 0.4.0-style export: checkpoints present, but no join-row arrays.
+    const legacy = path.join(exportsDir, 'legacy-export.json');
+    fs.mkdirSync(exportsDir, { recursive: true });
+    fs.writeFileSync(
+      legacy,
+      JSON.stringify({
+        version: '0.4.0',
+        session: { name: 'legacy', branch: 'main' },
+        contextItems: [{ id: 'old-1', key: 'legacy_key', value: 'legacy_value' }],
+        fileCache: [],
+        checkpoints: [{ id: 'old-cp', session_id: 'old-sess', name: 'legacy-cp' }],
+        // no checkpointItems / checkpointFiles keys
+      })
+    );
+    try {
+      const text = await callTool('context_import', { filePath: 'legacy-export.json' });
+      expect(text).toMatch(/Import successful/i);
+      expect(text).toMatch(/Context items:\s*1/);
+      expect(text).toMatch(/Checkpoints in file:\s*1 \(not imported/i);
+    } finally {
+      fs.rmSync(legacy, { force: true });
+    }
+  });
+
+  it('drops checkpoint links that point at skipped/absent rows', async () => {
+    // 0.5.0 export with a checkpoint whose item link references an id that is
+    // not present in contextItems — the checkpoint imports, the dangling link
+    // is dropped, and the import does not error.
+    const partial = path.join(exportsDir, 'partial-cp.json');
+    fs.mkdirSync(exportsDir, { recursive: true });
+    fs.writeFileSync(
+      partial,
+      JSON.stringify({
+        version: '0.5.0',
+        session: { name: 'partial', branch: 'main' },
+        contextItems: [{ id: 'item-1', key: 'k1', value: 'v1' }],
+        fileCache: [],
+        checkpoints: [{ id: 'cp-1', session_id: 's', name: 'partial-cp' }],
+        checkpointItems: [
+          { id: 'l1', checkpoint_id: 'cp-1', context_item_id: 'item-1' }, // valid
+          { id: 'l2', checkpoint_id: 'cp-1', context_item_id: 'missing' }, // dangling
+        ],
+        checkpointFiles: [],
+      })
+    );
+    try {
+      const text = await callTool('context_import', { filePath: 'partial-cp.json' });
+      expect(text).toMatch(/Import successful/i);
+      // 1 checkpoint, only the 1 valid link restored.
+      expect(text).toMatch(/Checkpoints:\s*1.*links restored:\s*1/);
+    } finally {
+      fs.rmSync(partial, { force: true });
+    }
+  });
+});

--- a/src/__tests__/e2e/checkpoint-round-trip.test.ts
+++ b/src/__tests__/e2e/checkpoint-round-trip.test.ts
@@ -14,55 +14,108 @@ import * as os from 'os';
  * The 0.5.0 export format adds `checkpointItems` / `checkpointFiles`, and import
  * rewires their foreign keys onto the freshly-generated ids.
  *
+ * The round-trip test imports into a SEPARATE server instance (its own
+ * DATA_DIR), so the only checkpoint named "cp-roundtrip" is the imported one —
+ * otherwise context_restore_checkpoint (which matches by name across all
+ * checkpoints) could resolve the original source checkpoint and mask a broken
+ * import.
+ *
  * @see https://github.com/mkreyman/mcp-memory-keeper/issues/37
  */
 
-let serverProcess: ChildProcess | null = null;
-let tempDir: string;
-let exportsDir: string;
-let msgId = 0;
-let outputBuffer = '';
+const SERVER_ENTRY = path.join(__dirname, '../../../dist/index.js');
 
-function sendRequest(
-  method: string,
-  params: Record<string, unknown> = {},
-  timeoutMs = 5000
-): Promise<any> {
-  return new Promise((resolve, reject) => {
-    const id = ++msgId;
-    const timeout = setTimeout(() => {
-      reject(new Error(`Timeout waiting for response to ${method} (id=${id})`));
-    }, timeoutMs);
-
-    const onData = (data: Buffer) => {
-      outputBuffer += data.toString();
-      const lines = outputBuffer.split('\n');
-      outputBuffer = lines.pop() || '';
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const msg = JSON.parse(line);
-          if (msg.id === id) {
-            clearTimeout(timeout);
-            serverProcess?.stdout?.removeListener('data', onData);
-            resolve(msg);
-          }
-        } catch {
-          // Not JSON, skip
-        }
-      }
-    };
-
-    serverProcess?.stdout?.on('data', onData);
-    serverProcess?.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params, id }) + '\n');
-  });
+/** A connected MCP server process with isolated JSON-RPC framing. */
+interface Client {
+  proc: ChildProcess;
+  dataDir: string;
+  exportsDir: string;
+  call: (name: string, args: Record<string, unknown>) => Promise<string>;
+  close: () => Promise<void>;
 }
 
-function callTool(name: string, args: Record<string, unknown>): Promise<string> {
-  return sendRequest('tools/call', { name, arguments: args }).then(
-    res => res.result?.content?.[0]?.text ?? JSON.stringify(res)
-  );
+async function startServer(): Promise<Client> {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-checkpoint-'));
+  const exportsDir = path.join(dataDir, 'exports');
+  const proc = spawn('node', [SERVER_ENTRY], {
+    env: { ...process.env, DATA_DIR: dataDir },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if ((global as any).testProcesses) {
+    (global as any).testProcesses.push(proc);
+  }
+
+  let buffer = '';
+  let nextId = 0;
+
+  const send = (method: string, params: Record<string, unknown>, id?: number): Promise<any> =>
+    new Promise((resolve, reject) => {
+      const reqId = id ?? ++nextId;
+      const timeout = setTimeout(() => {
+        proc.stdout?.removeListener('data', onData);
+        reject(new Error(`Timeout waiting for ${method} (id=${reqId})`));
+      }, 5000);
+
+      const onData = (data: Buffer) => {
+        buffer += data.toString();
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === reqId) {
+              clearTimeout(timeout);
+              proc.stdout?.removeListener('data', onData);
+              resolve(msg);
+            }
+          } catch {
+            // not JSON for us
+          }
+        }
+      };
+
+      proc.stdout?.on('data', onData);
+      proc.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method, params, id: reqId }) + '\n');
+    });
+
+  const init = await send('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'checkpoint-e2e', version: '1.0.0' },
+  });
+  expect(init.result).toHaveProperty('protocolVersion');
+  proc.stdin?.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  await new Promise(resolve => setTimeout(resolve, 150));
+
+  const call = async (name: string, args: Record<string, unknown>): Promise<string> => {
+    const res = await send('tools/call', { name, arguments: args });
+    return res.result?.content?.[0]?.text ?? JSON.stringify(res);
+  };
+
+  const close = async (): Promise<void> => {
+    if (!proc.killed) {
+      proc.kill('SIGTERM');
+      await new Promise<void>(resolve => {
+        const t = setTimeout(() => {
+          proc.kill('SIGKILL');
+          resolve();
+        }, 3000);
+        proc.on('exit', () => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+      proc.removeAllListeners();
+    }
+    try {
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  };
+
+  return { proc, dataDir, exportsDir, call, close };
 }
 
 /** Pull the export file path out of a context_export success message. */
@@ -73,68 +126,27 @@ function parseExportPath(exportText: string): string {
 }
 
 describe('E2E: checkpoint export/import round trip (issue #37)', () => {
+  let server: Client;
+
   beforeAll(async () => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-checkpoint-'));
-    exportsDir = path.join(tempDir, 'exports');
-
-    serverProcess = spawn('node', [path.join(__dirname, '../../../dist/index.js')], {
-      env: { ...process.env, DATA_DIR: tempDir },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
-    if ((global as any).testProcesses) {
-      (global as any).testProcesses.push(serverProcess);
-    }
-
-    const initResponse = await sendRequest('initialize', {
-      protocolVersion: '2024-11-05',
-      capabilities: {},
-      clientInfo: { name: 'checkpoint-e2e', version: '1.0.0' },
-    });
-    expect(initResponse.result).toHaveProperty('protocolVersion');
-
-    serverProcess?.stdin?.write(
-      JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n'
-    );
-    await new Promise(resolve => setTimeout(resolve, 200));
-  }, 10000);
+    server = await startServer();
+  }, 15000);
 
   afterAll(async () => {
-    if (serverProcess && !serverProcess.killed) {
-      serverProcess.kill('SIGTERM');
-      await new Promise<void>(resolve => {
-        const timeout = setTimeout(() => {
-          serverProcess?.kill('SIGKILL');
-          resolve();
-        }, 3000);
-        serverProcess?.on('exit', () => {
-          clearTimeout(timeout);
-          resolve();
-        });
-      });
-      serverProcess?.removeAllListeners();
-    }
-    serverProcess = null;
-
-    try {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    } catch {
-      // ignore cleanup errors
-    }
+    await server?.close();
   });
 
-  it('restores a checkpoint and its linked items + files through export -> import', async () => {
-    // Seed two items and a cached file in a fresh session.
-    await callTool('context_session_start', { name: 'cp-source' });
-    await callTool('context_save', { key: 'cp_item_a', value: 'value_a', category: 'task' });
-    await callTool('context_save', { key: 'cp_item_b', value: 'value_b', category: 'note' });
-    await callTool('context_cache_file', {
+  it('restores a checkpoint and its linked items + files into a clean instance', async () => {
+    // --- Source instance: seed, checkpoint, export ---
+    await server.call('context_session_start', { name: 'cp-source' });
+    await server.call('context_save', { key: 'cp_item_a', value: 'value_a', category: 'task' });
+    await server.call('context_save', { key: 'cp_item_b', value: 'value_b', category: 'note' });
+    await server.call('context_cache_file', {
       filePath: '/tmp/checkpoint-test.ts',
       content: 'cached file content',
     });
 
-    // Capture a checkpoint that links both items and the file.
-    const cpText = await callTool('context_checkpoint', {
+    const cpText = await server.call('context_checkpoint', {
       name: 'cp-roundtrip',
       description: 'round trip checkpoint',
       includeFiles: true,
@@ -143,32 +155,42 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
     expect(cpText).toMatch(/Created checkpoint/i);
     expect(cpText).toMatch(/Context items:\s*2/);
 
-    // Export, then import the produced file into a new session.
-    const exportText = await callTool('context_export', { confirmEmpty: true });
+    const exportText = await server.call('context_export', { confirmEmpty: true });
     const exportPath = parseExportPath(exportText);
-    expect(exportPath.startsWith(exportsDir)).toBe(true);
+    const exportBytes = fs.readFileSync(exportPath);
 
-    const importText = await callTool('context_import', { filePath: exportPath });
-    expect(importText).toMatch(/Import successful/i);
-    // The imported checkpoint must be restored with its links rewired: 2 item
-    // links + 1 file link = 3.
-    expect(importText).toMatch(/Checkpoints:\s*1.*links restored:\s*3/);
+    // --- Fresh instance: import the file, so the imported checkpoint is the
+    // ONLY one named "cp-roundtrip" (unambiguous restore-by-name). ---
+    const importer = await startServer();
+    try {
+      fs.mkdirSync(importer.exportsDir, { recursive: true });
+      const importFile = path.join(importer.exportsDir, 'incoming.json');
+      fs.writeFileSync(importFile, exportBytes);
 
-    // End-to-end proof: restoring the checkpoint by name reproduces its items
-    // and file (the join rows point at the freshly-imported rows).
-    const restoreText = await callTool('context_restore_checkpoint', {
-      name: 'cp-roundtrip',
-      restoreFiles: true,
-    });
-    expect(restoreText).toMatch(/Successfully restored from checkpoint/i);
-    expect(restoreText).toMatch(/Context items:\s*2/);
-    expect(restoreText).toMatch(/Files:\s*1/);
-  });
+      const importText = await importer.call('context_import', { filePath: 'incoming.json' });
+      expect(importText).toMatch(/Import successful/i);
+      expect(importText).toMatch(/Context items:\s*2/);
+      // 2 item links + 1 file link = 3, none dropped.
+      expect(importText).toMatch(/Checkpoints:\s*1, links restored:\s*3$/m);
+
+      // End-to-end proof: restoring reproduces the items AND the file, which can
+      // only be true if the join rows were rewired onto the freshly-imported
+      // rows in THIS instance.
+      const restoreText = await importer.call('context_restore_checkpoint', {
+        name: 'cp-roundtrip',
+        restoreFiles: true,
+      });
+      expect(restoreText).toMatch(/Successfully restored from checkpoint/i);
+      expect(restoreText).toMatch(/Context items:\s*2/);
+      expect(restoreText).toMatch(/Files:\s*1/);
+    } finally {
+      await importer.close();
+    }
+  }, 20000);
 
   it('reports legacy exports (no checkpointItems) as not imported, without error', async () => {
-    // A 0.4.0-style export: checkpoints present, but no join-row arrays.
-    const legacy = path.join(exportsDir, 'legacy-export.json');
-    fs.mkdirSync(exportsDir, { recursive: true });
+    const legacy = path.join(server.exportsDir, 'legacy-export.json');
+    fs.mkdirSync(server.exportsDir, { recursive: true });
     fs.writeFileSync(
       legacy,
       JSON.stringify({
@@ -181,7 +203,7 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
       })
     );
     try {
-      const text = await callTool('context_import', { filePath: 'legacy-export.json' });
+      const text = await server.call('context_import', { filePath: 'legacy-export.json' });
       expect(text).toMatch(/Import successful/i);
       expect(text).toMatch(/Context items:\s*1/);
       expect(text).toMatch(/Checkpoints in file:\s*1 \(not imported/i);
@@ -190,12 +212,12 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
     }
   });
 
-  it('drops checkpoint links that point at skipped/absent rows', async () => {
+  it('drops checkpoint links that point at skipped/absent rows and proves DB state', async () => {
     // 0.5.0 export with a checkpoint whose item link references an id that is
-    // not present in contextItems — the checkpoint imports, the dangling link
-    // is dropped, and the import does not error.
-    const partial = path.join(exportsDir, 'partial-cp.json');
-    fs.mkdirSync(exportsDir, { recursive: true });
+    // not present in contextItems — the checkpoint imports, the dangling link is
+    // dropped, and a subsequent restore yields exactly the one valid item.
+    const partial = path.join(server.exportsDir, 'partial-cp.json');
+    fs.mkdirSync(server.exportsDir, { recursive: true });
     fs.writeFileSync(
       partial,
       JSON.stringify({
@@ -212,10 +234,17 @@ describe('E2E: checkpoint export/import round trip (issue #37)', () => {
       })
     );
     try {
-      const text = await callTool('context_import', { filePath: 'partial-cp.json' });
+      const text = await server.call('context_import', { filePath: 'partial-cp.json' });
       expect(text).toMatch(/Import successful/i);
-      // 1 checkpoint, only the 1 valid link restored.
-      expect(text).toMatch(/Checkpoints:\s*1.*links restored:\s*1/);
+      // 1 checkpoint, only the 1 valid link restored, 1 dangling link dropped.
+      expect(text).toMatch(/Checkpoints:\s*1, links restored:\s*1 \(dropped 1 dangling\)/);
+
+      // "partial-cp" is unique here, so restore-by-name is unambiguous.
+      const restoreText = await server.call('context_restore_checkpoint', {
+        name: 'partial-cp',
+        restoreFiles: true,
+      });
+      expect(restoreText).toMatch(/Context items:\s*1/); // not 2 — dangling link was dropped
     } finally {
       fs.rmSync(partial, { force: true });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { v4 as uuidv4 } from 'uuid';
+import type Database from 'better-sqlite3';
 import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -127,6 +128,138 @@ function resolveConfinedImportPath(filePath: unknown): string {
   }
 
   return resolved;
+}
+
+// Shapes of the (untrusted) checkpoint rows in a 0.5.0+ import payload. Fields
+// are `unknown` because they come straight from JSON.parse and are validated at
+// runtime before use.
+interface ImportedCheckpoint {
+  id?: unknown;
+  name?: unknown;
+  description?: unknown;
+  metadata?: unknown;
+  git_status?: unknown;
+  git_branch?: unknown;
+  created_at?: unknown;
+}
+
+interface ImportedCheckpointLink {
+  checkpoint_id?: unknown;
+  context_item_id?: unknown;
+  file_cache_id?: unknown;
+}
+
+interface CheckpointRestoreResult {
+  checkpointCount: number;
+  skippedCheckpoints: number;
+  checkpointLinkCount: number;
+  droppedCheckpointLinks: number;
+}
+
+/**
+ * Restore checkpoints and their checkpoint_items / checkpoint_files join rows
+ * from a 0.5.0+ import payload. MUST be called inside the import transaction so
+ * its inserts are atomic with the rest of the import.
+ *
+ * Each checkpoint gets a fresh id; join rows are rewired onto the new item/file
+ * ids via the supplied maps. Malformed checkpoints are skipped, and links
+ * pointing at a skipped or absent row are dropped (never inserted — that would
+ * violate a foreign key).
+ */
+function restoreImportedCheckpoints(
+  db: Database.Database,
+  targetSessionId: string,
+  checkpointEntries: unknown[],
+  checkpointItemEntries: unknown[],
+  checkpointFileEntries: unknown[],
+  itemIdMap: Map<string, string>,
+  fileIdMap: Map<string, string>
+): CheckpointRestoreResult {
+  let checkpointCount = 0;
+  let skippedCheckpoints = 0;
+  let checkpointLinkCount = 0;
+  let droppedCheckpointLinks = 0;
+
+  const checkpointIdMap = new Map<string, string>();
+  const cpStmt = db.prepare(`
+    INSERT INTO checkpoints (id, session_id, name, description, metadata, git_status, git_branch, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const entry of checkpointEntries) {
+    const cp = entry as ImportedCheckpoint;
+    if (
+      typeof cp !== 'object' ||
+      cp === null ||
+      typeof cp.id !== 'string' ||
+      typeof cp.name !== 'string'
+    ) {
+      skippedCheckpoints++;
+      continue;
+    }
+    const newCpId = uuidv4();
+    checkpointIdMap.set(cp.id, newCpId);
+    cpStmt.run(
+      newCpId,
+      targetSessionId,
+      cp.name,
+      typeof cp.description === 'string' ? cp.description : null,
+      typeof cp.metadata === 'string' ? cp.metadata : null,
+      typeof cp.git_status === 'string' ? cp.git_status : null,
+      typeof cp.git_branch === 'string' ? cp.git_branch : null,
+      typeof cp.created_at === 'string' ? cp.created_at : new Date().toISOString()
+    );
+    checkpointCount++;
+  }
+
+  const cpiStmt = db.prepare(
+    'INSERT INTO checkpoint_items (id, checkpoint_id, context_item_id) VALUES (?, ?, ?)'
+  );
+  for (const entry of checkpointItemEntries) {
+    const link = entry as ImportedCheckpointLink;
+    if (
+      typeof link !== 'object' ||
+      link === null ||
+      typeof link.checkpoint_id !== 'string' ||
+      typeof link.context_item_id !== 'string'
+    ) {
+      droppedCheckpointLinks++;
+      continue;
+    }
+    const newCpId = checkpointIdMap.get(link.checkpoint_id);
+    const newItemId = itemIdMap.get(link.context_item_id);
+    if (!newCpId || !newItemId) {
+      droppedCheckpointLinks++;
+      continue;
+    }
+    cpiStmt.run(uuidv4(), newCpId, newItemId);
+    checkpointLinkCount++;
+  }
+
+  const cpfStmt = db.prepare(
+    'INSERT INTO checkpoint_files (id, checkpoint_id, file_cache_id) VALUES (?, ?, ?)'
+  );
+  for (const entry of checkpointFileEntries) {
+    const link = entry as ImportedCheckpointLink;
+    if (
+      typeof link !== 'object' ||
+      link === null ||
+      typeof link.checkpoint_id !== 'string' ||
+      typeof link.file_cache_id !== 'string'
+    ) {
+      droppedCheckpointLinks++;
+      continue;
+    }
+    const newCpId = checkpointIdMap.get(link.checkpoint_id);
+    const newFileId = fileIdMap.get(link.file_cache_id);
+    if (!newCpId || !newFileId) {
+      droppedCheckpointLinks++;
+      continue;
+    }
+    cpfStmt.run(uuidv4(), newCpId, newFileId);
+    checkpointLinkCount++;
+  }
+
+  return { checkpointCount, skippedCheckpoints, checkpointLinkCount, droppedCheckpointLinks };
 }
 
 // Warn users whose legacy DB is sitting in CWD
@@ -2168,93 +2301,24 @@ Files: ${stats.files}`) + sizeWarning,
             fileCount++;
           }
 
-          // Restore checkpoints and their links (0.5.0+ exports only). Each
-          // checkpoint gets a fresh id; its join rows are rewired onto the new
-          // item/file ids via the maps built above. Links pointing at a row that
-          // was skipped or absent are dropped.
-          let checkpointCount = 0;
-          let skippedCheckpoints = 0;
-          let checkpointLinkCount = 0;
-          let droppedCheckpointLinks = 0;
-          if (checkpointFormatSupported) {
-            const checkpointIdMap = new Map<string, string>();
-            const cpStmt = db.prepare(`
-              INSERT INTO checkpoints (id, session_id, name, description, metadata, git_status, git_branch, created_at)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            `);
-            for (const cp of checkpointEntries) {
-              if (
-                typeof cp !== 'object' ||
-                cp === null ||
-                typeof cp.id !== 'string' ||
-                typeof cp.name !== 'string'
-              ) {
-                skippedCheckpoints++;
-                continue;
-              }
-              const newCpId = uuidv4();
-              checkpointIdMap.set(cp.id, newCpId);
-              cpStmt.run(
-                newCpId,
+          // Restore checkpoints + their links (0.5.0+ exports only), within this
+          // same transaction. Extracted to a helper to keep the handler readable.
+          const cp: CheckpointRestoreResult = checkpointFormatSupported
+            ? restoreImportedCheckpoints(
+                db,
                 targetSessionId,
-                cp.name,
-                typeof cp.description === 'string' ? cp.description : null,
-                typeof cp.metadata === 'string' ? cp.metadata : null,
-                typeof cp.git_status === 'string' ? cp.git_status : null,
-                typeof cp.git_branch === 'string' ? cp.git_branch : null,
-                typeof cp.created_at === 'string' ? cp.created_at : new Date().toISOString()
-              );
-              checkpointCount++;
-            }
-
-            const cpiStmt = db.prepare(
-              'INSERT INTO checkpoint_items (id, checkpoint_id, context_item_id) VALUES (?, ?, ?)'
-            );
-            for (const link of checkpointItemEntries) {
-              if (
-                typeof link !== 'object' ||
-                link === null ||
-                typeof link.checkpoint_id !== 'string' ||
-                typeof link.context_item_id !== 'string'
-              ) {
-                droppedCheckpointLinks++;
-                continue;
-              }
-              const newCpId = checkpointIdMap.get(link.checkpoint_id);
-              const newItemId = itemIdMap.get(link.context_item_id);
-              // A link to a checkpoint/item that was skipped or absent is dropped
-              // rather than inserted (which would violate the foreign key).
-              if (!newCpId || !newItemId) {
-                droppedCheckpointLinks++;
-                continue;
-              }
-              cpiStmt.run(uuidv4(), newCpId, newItemId);
-              checkpointLinkCount++;
-            }
-
-            const cpfStmt = db.prepare(
-              'INSERT INTO checkpoint_files (id, checkpoint_id, file_cache_id) VALUES (?, ?, ?)'
-            );
-            for (const link of checkpointFileEntries) {
-              if (
-                typeof link !== 'object' ||
-                link === null ||
-                typeof link.checkpoint_id !== 'string' ||
-                typeof link.file_cache_id !== 'string'
-              ) {
-                droppedCheckpointLinks++;
-                continue;
-              }
-              const newCpId = checkpointIdMap.get(link.checkpoint_id);
-              const newFileId = fileIdMap.get(link.file_cache_id);
-              if (!newCpId || !newFileId) {
-                droppedCheckpointLinks++;
-                continue;
-              }
-              cpfStmt.run(uuidv4(), newCpId, newFileId);
-              checkpointLinkCount++;
-            }
-          }
+                checkpointEntries,
+                checkpointItemEntries,
+                checkpointFileEntries,
+                itemIdMap,
+                fileIdMap
+              )
+            : {
+                checkpointCount: 0,
+                skippedCheckpoints: 0,
+                checkpointLinkCount: 0,
+                droppedCheckpointLinks: 0,
+              };
 
           return {
             targetSessionId,
@@ -2263,10 +2327,10 @@ Files: ${stats.files}`) + sizeWarning,
             fileCount,
             skippedItems,
             skippedFiles,
-            checkpointCount,
-            skippedCheckpoints,
-            checkpointLinkCount,
-            droppedCheckpointLinks,
+            checkpointCount: cp.checkpointCount,
+            skippedCheckpoints: cp.skippedCheckpoints,
+            checkpointLinkCount: cp.checkpointLinkCount,
+            droppedCheckpointLinks: cp.droppedCheckpointLinks,
             collapsedItems,
             collapsedFiles,
           };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1723,6 +1723,23 @@ Checkpoint: ${autoSave ? `git-commit-${new Date().toISOString()}` : 'None'}`,
       const checkpoints = db
         .prepare('SELECT * FROM checkpoints WHERE session_id = ?')
         .all(targetSessionId);
+      // The join rows that link a checkpoint to the context items / files it
+      // captured. Without these, an imported checkpoint would be empty, so they
+      // are part of the export payload (format version 0.5.0+).
+      const checkpointItems = db
+        .prepare(
+          `SELECT cpi.* FROM checkpoint_items cpi
+           JOIN checkpoints cp ON cpi.checkpoint_id = cp.id
+           WHERE cp.session_id = ?`
+        )
+        .all(targetSessionId);
+      const checkpointFiles = db
+        .prepare(
+          `SELECT cpf.* FROM checkpoint_files cpf
+           JOIN checkpoints cp ON cpf.checkpoint_id = cp.id
+           WHERE cp.session_id = ?`
+        )
+        .all(targetSessionId);
 
       // Check if session is empty
       const isEmpty =
@@ -1741,12 +1758,17 @@ Checkpoint: ${autoSave ? `git-commit-${new Date().toISOString()}` : 'None'}`,
       }
 
       const exportData = {
-        version: '0.4.0',
+        // 0.5.0 added checkpointItems / checkpointFiles so checkpoints survive
+        // a round trip. Older importers ignore the new keys; newer importers
+        // treat their absence as "legacy export, checkpoints not importable".
+        version: '0.5.0',
         exported: new Date().toISOString(),
         session,
         contextItems,
         fileCache,
         checkpoints,
+        checkpointItems,
+        checkpointFiles,
         metadata: {
           itemCount: contextItems.length,
           fileCount: fileCache.length,
@@ -1884,12 +1906,26 @@ Files: ${stats.files}`) + sizeWarning,
       const merged = merge && !!currentSessionId;
 
       const fileCacheEntries = Array.isArray(importData.fileCache) ? importData.fileCache : [];
+      const checkpointEntries = Array.isArray(importData.checkpoints) ? importData.checkpoints : [];
+      const checkpointItemEntries = Array.isArray(importData.checkpointItems)
+        ? importData.checkpointItems
+        : [];
+      const checkpointFileEntries = Array.isArray(importData.checkpointFiles)
+        ? importData.checkpointFiles
+        : [];
+      // Presence of the checkpointItems key marks a 0.5.0+ export that carries
+      // the join rows needed to restore checkpoints faithfully. Older exports
+      // lack it, so their checkpoints are reported as not imported.
+      const checkpointFormatSupported = Array.isArray(importData.checkpointItems);
 
       // Bound the work before opening the (synchronous, event-loop-blocking)
       // transaction so a huge row count cannot stall the server.
       if (
         importData.contextItems.length > MAX_IMPORT_ITEMS ||
-        fileCacheEntries.length > MAX_IMPORT_ITEMS
+        fileCacheEntries.length > MAX_IMPORT_ITEMS ||
+        checkpointEntries.length > MAX_IMPORT_ITEMS ||
+        checkpointItemEntries.length > MAX_IMPORT_ITEMS ||
+        checkpointFileEntries.length > MAX_IMPORT_ITEMS
       ) {
         return {
           content: [
@@ -1938,6 +1974,11 @@ Files: ${stats.files}`) + sizeWarning,
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
           `);
 
+          // Map each exported row's id to the new id we generate, so checkpoint
+          // join rows can be rewired onto the freshly-imported items/files.
+          const itemIdMap = new Map<string, string>();
+          const fileIdMap = new Map<string, string>();
+
           let itemCount = 0;
           let skippedItems = 0;
           for (const item of importData.contextItems) {
@@ -1952,8 +1993,12 @@ Files: ${stats.files}`) + sizeWarning,
               skippedItems++;
               continue;
             }
+            const newItemId = uuidv4();
+            if (typeof item.id === 'string') {
+              itemIdMap.set(item.id, newItemId);
+            }
             itemStmt.run(
-              uuidv4(),
+              newItemId,
               targetSessionId,
               item.key,
               item.value,
@@ -1991,8 +2036,12 @@ Files: ${stats.files}`) + sizeWarning,
               skippedFiles++;
               continue;
             }
+            const newFileId = uuidv4();
+            if (typeof file.id === 'string') {
+              fileIdMap.set(file.id, newFileId);
+            }
             fileStmt.run(
-              uuidv4(),
+              newFileId,
               targetSessionId,
               file.file_path,
               file.content ?? null,
@@ -2002,7 +2051,80 @@ Files: ${stats.files}`) + sizeWarning,
             fileCount++;
           }
 
-          return { targetSessionId, createdNew, itemCount, fileCount, skippedItems, skippedFiles };
+          // Restore checkpoints and their links (0.5.0+ exports only). Each
+          // checkpoint gets a fresh id; its join rows are rewired onto the new
+          // item/file ids via the maps built above. Links pointing at a row that
+          // was skipped or absent are dropped.
+          let checkpointCount = 0;
+          let skippedCheckpoints = 0;
+          let checkpointLinkCount = 0;
+          if (checkpointFormatSupported) {
+            const checkpointIdMap = new Map<string, string>();
+            const cpStmt = db.prepare(`
+              INSERT INTO checkpoints (id, session_id, name, description, metadata, git_status, git_branch, created_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            `);
+            for (const cp of checkpointEntries) {
+              if (
+                typeof cp !== 'object' ||
+                cp === null ||
+                typeof cp.id !== 'string' ||
+                typeof cp.name !== 'string'
+              ) {
+                skippedCheckpoints++;
+                continue;
+              }
+              const newCpId = uuidv4();
+              checkpointIdMap.set(cp.id, newCpId);
+              cpStmt.run(
+                newCpId,
+                targetSessionId,
+                cp.name,
+                typeof cp.description === 'string' ? cp.description : null,
+                typeof cp.metadata === 'string' ? cp.metadata : null,
+                typeof cp.git_status === 'string' ? cp.git_status : null,
+                typeof cp.git_branch === 'string' ? cp.git_branch : null,
+                typeof cp.created_at === 'string' ? cp.created_at : new Date().toISOString()
+              );
+              checkpointCount++;
+            }
+
+            const cpiStmt = db.prepare(
+              'INSERT INTO checkpoint_items (id, checkpoint_id, context_item_id) VALUES (?, ?, ?)'
+            );
+            for (const link of checkpointItemEntries) {
+              if (typeof link !== 'object' || link === null) continue;
+              const newCpId = checkpointIdMap.get(link.checkpoint_id);
+              const newItemId = itemIdMap.get(link.context_item_id);
+              if (!newCpId || !newItemId) continue;
+              cpiStmt.run(uuidv4(), newCpId, newItemId);
+              checkpointLinkCount++;
+            }
+
+            const cpfStmt = db.prepare(
+              'INSERT INTO checkpoint_files (id, checkpoint_id, file_cache_id) VALUES (?, ?, ?)'
+            );
+            for (const link of checkpointFileEntries) {
+              if (typeof link !== 'object' || link === null) continue;
+              const newCpId = checkpointIdMap.get(link.checkpoint_id);
+              const newFileId = fileIdMap.get(link.file_cache_id);
+              if (!newCpId || !newFileId) continue;
+              cpfStmt.run(uuidv4(), newCpId, newFileId);
+              checkpointLinkCount++;
+            }
+          }
+
+          return {
+            targetSessionId,
+            createdNew,
+            itemCount,
+            fileCount,
+            skippedItems,
+            skippedFiles,
+            checkpointCount,
+            skippedCheckpoints,
+            checkpointLinkCount,
+          };
         });
 
         const result = runImport();
@@ -2018,13 +2140,21 @@ Files: ${stats.files}`) + sizeWarning,
           `Files: ${result.fileCount}${result.skippedFiles ? ` (skipped ${result.skippedFiles} malformed)` : ''}`,
           `Mode: ${result.createdNew ? 'New session' : 'Merged'}`,
         ];
-        // Checkpoints are present in exports but not restored by import; say so
-        // explicitly instead of silently dropping them.
-        const checkpointCount = Array.isArray(importData.checkpoints)
-          ? importData.checkpoints.length
-          : 0;
-        if (checkpointCount > 0) {
-          lines.push(`Checkpoints in file: ${checkpointCount} (not imported)`);
+        // Report checkpoints: restored for 0.5.0+ exports, or flagged as not
+        // imported for legacy exports that lack the join rows.
+        if (checkpointFormatSupported) {
+          if (result.checkpointCount > 0 || checkpointEntries.length > 0) {
+            const skipNote = result.skippedCheckpoints
+              ? ` (skipped ${result.skippedCheckpoints} malformed)`
+              : '';
+            lines.push(
+              `Checkpoints: ${result.checkpointCount}${skipNote}, links restored: ${result.checkpointLinkCount}`
+            );
+          }
+        } else if (checkpointEntries.length > 0) {
+          lines.push(
+            `Checkpoints in file: ${checkpointEntries.length} (not imported — re-export with v0.5.0+ to include them)`
+          );
         }
         // Warn when the caller asked to merge but there was no active session.
         if (merge && !merged) {
@@ -4584,7 +4714,8 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     {
       name: 'context_export',
       description:
-        'Export session data for backup or sharing. JSON exports are written to the ' +
+        'Export session data (context items, cached files, and checkpoints with their ' +
+        'links) for backup or sharing. JSON exports are written to the ' +
         "server's exports directory (<DATA_DIR>/exports, overridable via MEMORY_KEEPER_EXPORT_DIR); " +
         'the response includes the full path, which can be passed back to context_import.',
       inputSchema: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1773,7 +1773,13 @@ Checkpoint: ${autoSave ? `git-commit-${new Date().toISOString()}` : 'None'}`,
           itemCount: contextItems.length,
           fileCount: fileCache.length,
           checkpointCount: checkpoints.length,
-          totalSize: JSON.stringify({ contextItems, fileCache, checkpoints }).length,
+          totalSize: JSON.stringify({
+            contextItems,
+            fileCache,
+            checkpoints,
+            checkpointItems,
+            checkpointFiles,
+          }).length,
         },
       };
 
@@ -1919,7 +1925,11 @@ Files: ${stats.files}`) + sizeWarning,
       const checkpointFormatSupported = Array.isArray(importData.checkpointItems);
 
       // Bound the work before opening the (synchronous, event-loop-blocking)
-      // transaction so a huge row count cannot stall the server.
+      // transaction so a huge row count cannot stall the server. The cap is
+      // per-array on purpose: checkpoint_items legitimately scales as
+      // (checkpoints × items), so it routinely exceeds the item count, and an
+      // aggregate sum cap would reject valid many-checkpoint sessions. The
+      // 50 MB MAX_IMPORT_BYTES cap bounds the total payload independently.
       if (
         importData.contextItems.length > MAX_IMPORT_ITEMS ||
         fileCacheEntries.length > MAX_IMPORT_ITEMS ||
@@ -1979,8 +1989,17 @@ Files: ${stats.files}`) + sizeWarning,
           const itemIdMap = new Map<string, string>();
           const fileIdMap = new Map<string, string>();
 
-          let itemCount = 0;
+          // De-duplicate by the natural key (session_id is implied) BEFORE
+          // inserting. context_items has UNIQUE(session_id, key), so two exported
+          // items sharing a key would otherwise INSERT OR REPLACE-collapse — the
+          // first row (still in itemIdMap) would be deleted, leaving the map
+          // pointing at a row that no longer exists and making a later
+          // checkpoint_items insert throw an FK error that aborts the whole
+          // import. Keeping the last occurrence matches INSERT OR REPLACE
+          // semantics; every exported id for that key is mapped to the survivor.
           let skippedItems = 0;
+          const itemsByKey = new Map<string, any>();
+          const itemOldIdsByKey = new Map<string, string[]>();
           for (const item of importData.contextItems) {
             // Skip entries that are not well-formed items rather than letting a
             // bad row abort the whole transaction with a SQLite binding error.
@@ -1993,9 +2012,19 @@ Files: ${stats.files}`) + sizeWarning,
               skippedItems++;
               continue;
             }
-            const newItemId = uuidv4();
+            itemsByKey.set(item.key, item);
+            const oldIds = itemOldIdsByKey.get(item.key) ?? [];
             if (typeof item.id === 'string') {
-              itemIdMap.set(item.id, newItemId);
+              oldIds.push(item.id);
+            }
+            itemOldIdsByKey.set(item.key, oldIds);
+          }
+
+          let itemCount = 0;
+          for (const [key, item] of itemsByKey) {
+            const newItemId = uuidv4();
+            for (const oldId of itemOldIdsByKey.get(key) ?? []) {
+              itemIdMap.set(oldId, newItemId);
             }
             itemStmt.run(
               newItemId,
@@ -2019,13 +2048,17 @@ Files: ${stats.files}`) + sizeWarning,
 
           // Import file cache. content is a nullable column, so null is valid and
           // must NOT be treated as a malformed row (that would drop legit rows).
+          // size is restored too so the round trip is faithful. Like context
+          // items, file_cache has UNIQUE(session_id, file_path), so de-duplicate
+          // by file_path (keep last) to avoid stranding fileIdMap on a collapse.
           const fileStmt = db.prepare(`
-            INSERT OR REPLACE INTO file_cache (id, session_id, file_path, content, hash, last_read)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO file_cache (id, session_id, file_path, content, hash, size, last_read)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
           `);
 
-          let fileCount = 0;
           let skippedFiles = 0;
+          const filesByPath = new Map<string, any>();
+          const fileOldIdsByPath = new Map<string, string[]>();
           for (const file of fileCacheEntries) {
             if (
               typeof file !== 'object' ||
@@ -2036,16 +2069,32 @@ Files: ${stats.files}`) + sizeWarning,
               skippedFiles++;
               continue;
             }
-            const newFileId = uuidv4();
+            filesByPath.set(file.file_path, file);
+            const oldIds = fileOldIdsByPath.get(file.file_path) ?? [];
             if (typeof file.id === 'string') {
-              fileIdMap.set(file.id, newFileId);
+              oldIds.push(file.id);
             }
+            fileOldIdsByPath.set(file.file_path, oldIds);
+          }
+
+          let fileCount = 0;
+          for (const [filePath, file] of filesByPath) {
+            const newFileId = uuidv4();
+            for (const oldId of fileOldIdsByPath.get(filePath) ?? []) {
+              fileIdMap.set(oldId, newFileId);
+            }
+            const content = file.content ?? null;
             fileStmt.run(
               newFileId,
               targetSessionId,
               file.file_path,
-              file.content ?? null,
+              content,
               typeof file.hash === 'string' ? file.hash : null,
+              typeof file.size === 'number' && file.size >= 0
+                ? file.size
+                : typeof content === 'string'
+                  ? calculateSize(content)
+                  : 0,
               typeof file.last_read === 'string' ? file.last_read : null
             );
             fileCount++;
@@ -2058,6 +2107,7 @@ Files: ${stats.files}`) + sizeWarning,
           let checkpointCount = 0;
           let skippedCheckpoints = 0;
           let checkpointLinkCount = 0;
+          let droppedCheckpointLinks = 0;
           if (checkpointFormatSupported) {
             const checkpointIdMap = new Map<string, string>();
             const cpStmt = db.prepare(`
@@ -2093,10 +2143,23 @@ Files: ${stats.files}`) + sizeWarning,
               'INSERT INTO checkpoint_items (id, checkpoint_id, context_item_id) VALUES (?, ?, ?)'
             );
             for (const link of checkpointItemEntries) {
-              if (typeof link !== 'object' || link === null) continue;
+              if (
+                typeof link !== 'object' ||
+                link === null ||
+                typeof link.checkpoint_id !== 'string' ||
+                typeof link.context_item_id !== 'string'
+              ) {
+                droppedCheckpointLinks++;
+                continue;
+              }
               const newCpId = checkpointIdMap.get(link.checkpoint_id);
               const newItemId = itemIdMap.get(link.context_item_id);
-              if (!newCpId || !newItemId) continue;
+              // A link to a checkpoint/item that was skipped or absent is dropped
+              // rather than inserted (which would violate the foreign key).
+              if (!newCpId || !newItemId) {
+                droppedCheckpointLinks++;
+                continue;
+              }
               cpiStmt.run(uuidv4(), newCpId, newItemId);
               checkpointLinkCount++;
             }
@@ -2105,10 +2168,21 @@ Files: ${stats.files}`) + sizeWarning,
               'INSERT INTO checkpoint_files (id, checkpoint_id, file_cache_id) VALUES (?, ?, ?)'
             );
             for (const link of checkpointFileEntries) {
-              if (typeof link !== 'object' || link === null) continue;
+              if (
+                typeof link !== 'object' ||
+                link === null ||
+                typeof link.checkpoint_id !== 'string' ||
+                typeof link.file_cache_id !== 'string'
+              ) {
+                droppedCheckpointLinks++;
+                continue;
+              }
               const newCpId = checkpointIdMap.get(link.checkpoint_id);
               const newFileId = fileIdMap.get(link.file_cache_id);
-              if (!newCpId || !newFileId) continue;
+              if (!newCpId || !newFileId) {
+                droppedCheckpointLinks++;
+                continue;
+              }
               cpfStmt.run(uuidv4(), newCpId, newFileId);
               checkpointLinkCount++;
             }
@@ -2124,6 +2198,7 @@ Files: ${stats.files}`) + sizeWarning,
             checkpointCount,
             skippedCheckpoints,
             checkpointLinkCount,
+            droppedCheckpointLinks,
           };
         });
 
@@ -2147,8 +2222,11 @@ Files: ${stats.files}`) + sizeWarning,
             const skipNote = result.skippedCheckpoints
               ? ` (skipped ${result.skippedCheckpoints} malformed)`
               : '';
+            const dropNote = result.droppedCheckpointLinks
+              ? ` (dropped ${result.droppedCheckpointLinks} dangling)`
+              : '';
             lines.push(
-              `Checkpoints: ${result.checkpointCount}${skipNote}, links restored: ${result.checkpointLinkCount}`
+              `Checkpoints: ${result.checkpointCount}${skipNote}, links restored: ${result.checkpointLinkCount}${dropNote}`
             );
           }
         } else if (checkpointEntries.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1977,11 +1977,22 @@ Files: ${stats.files}`) + sizeWarning,
             );
           }
 
-          // Import context items. Restore the channel/is_private/metadata columns
-          // too so a round trip is faithful, not lossy.
-          const itemStmt = db.prepare(`
-            INSERT OR REPLACE INTO context_items (id, session_id, key, value, category, priority, size, metadata, is_private, channel, created_at, updated_at)
+          // Import context items, restoring channel/is_private/metadata so the
+          // round trip is faithful. On a key collision we UPDATE the existing row
+          // in place (preserving its id) rather than INSERT OR REPLACE: REPLACE
+          // would delete the row and ON DELETE CASCADE would silently strip a
+          // pre-existing checkpoint's link to it. Preserving the id keeps links.
+          const insertItemStmt = db.prepare(`
+            INSERT INTO context_items (id, session_id, key, value, category, priority, size, metadata, is_private, channel, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+          `);
+          const findItemStmt = db.prepare(
+            'SELECT id FROM context_items WHERE session_id = ? AND key = ?'
+          );
+          const updateItemStmt = db.prepare(`
+            UPDATE context_items
+            SET value = ?, category = ?, priority = ?, size = ?, metadata = ?, is_private = ?, channel = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
           `);
 
           // Map each exported row's id to the new id we generate, so checkpoint
@@ -1998,6 +2009,7 @@ Files: ${stats.files}`) + sizeWarning,
           // import. Keeping the last occurrence matches INSERT OR REPLACE
           // semantics; every exported id for that key is mapped to the survivor.
           let skippedItems = 0;
+          let validItems = 0;
           const itemsByKey = new Map<string, any>();
           const itemOldIdsByKey = new Map<string, string[]>();
           for (const item of importData.contextItems) {
@@ -2012,6 +2024,7 @@ Files: ${stats.files}`) + sizeWarning,
               skippedItems++;
               continue;
             }
+            validItems++;
             itemsByKey.set(item.key, item);
             const oldIds = itemOldIdsByKey.get(item.key) ?? [];
             if (typeof item.id === 'string') {
@@ -2019,44 +2032,83 @@ Files: ${stats.files}`) + sizeWarning,
             }
             itemOldIdsByKey.set(item.key, oldIds);
           }
+          // Valid rows that collapsed onto an earlier duplicate key.
+          const collapsedItems = validItems - itemsByKey.size;
 
           let itemCount = 0;
           for (const [key, item] of itemsByKey) {
-            const newItemId = uuidv4();
-            for (const oldId of itemOldIdsByKey.get(key) ?? []) {
-              itemIdMap.set(oldId, newItemId);
+            const value = item.value;
+            const category = typeof item.category === 'string' ? item.category : null;
+            const priority = typeof item.priority === 'string' ? item.priority : null;
+            // Use the stored size only when it is a valid non-negative number;
+            // `|| calculateSize(...)` would wrongly recompute a legitimate 0.
+            const size =
+              typeof item.size === 'number' && item.size >= 0 ? item.size : calculateSize(value);
+            const metadata = typeof item.metadata === 'string' ? item.metadata : null;
+            const isPrivate = typeof item.is_private === 'number' ? item.is_private : 0;
+            const channel = typeof item.channel === 'string' ? item.channel : 'general';
+
+            // In merge mode, reuse the existing row id on a key collision so its
+            // existing checkpoint links are preserved (no REPLACE-cascade).
+            const existing = merged
+              ? (findItemStmt.get(targetSessionId, key) as { id: string } | undefined)
+              : undefined;
+            let targetItemId: string;
+            if (existing) {
+              targetItemId = existing.id;
+              updateItemStmt.run(
+                value,
+                category,
+                priority,
+                size,
+                metadata,
+                isPrivate,
+                channel,
+                targetItemId
+              );
+            } else {
+              targetItemId = uuidv4();
+              insertItemStmt.run(
+                targetItemId,
+                targetSessionId,
+                key,
+                value,
+                category,
+                priority,
+                size,
+                metadata,
+                isPrivate,
+                channel,
+                typeof item.created_at === 'string' ? item.created_at : new Date().toISOString()
+              );
             }
-            itemStmt.run(
-              newItemId,
-              targetSessionId,
-              item.key,
-              item.value,
-              typeof item.category === 'string' ? item.category : null,
-              typeof item.priority === 'string' ? item.priority : null,
-              // Use the stored size only when it is a valid non-negative number;
-              // `|| calculateSize(...)` would wrongly recompute a legitimate 0.
-              typeof item.size === 'number' && item.size >= 0
-                ? item.size
-                : calculateSize(item.value),
-              typeof item.metadata === 'string' ? item.metadata : null,
-              typeof item.is_private === 'number' ? item.is_private : 0,
-              typeof item.channel === 'string' ? item.channel : 'general',
-              typeof item.created_at === 'string' ? item.created_at : new Date().toISOString()
-            );
+            for (const oldId of itemOldIdsByKey.get(key) ?? []) {
+              itemIdMap.set(oldId, targetItemId);
+            }
             itemCount++;
           }
 
           // Import file cache. content is a nullable column, so null is valid and
           // must NOT be treated as a malformed row (that would drop legit rows).
           // size is restored too so the round trip is faithful. Like context
-          // items, file_cache has UNIQUE(session_id, file_path), so de-duplicate
-          // by file_path (keep last) to avoid stranding fileIdMap on a collapse.
-          const fileStmt = db.prepare(`
-            INSERT OR REPLACE INTO file_cache (id, session_id, file_path, content, hash, size, last_read)
+          // items, file_cache has UNIQUE(session_id, file_path); de-duplicate by
+          // file_path and UPDATE-in-place on collision (preserving the id, hence
+          // any pre-existing checkpoint_files link) rather than INSERT OR REPLACE.
+          const insertFileStmt = db.prepare(`
+            INSERT INTO file_cache (id, session_id, file_path, content, hash, size, last_read)
             VALUES (?, ?, ?, ?, ?, ?, ?)
+          `);
+          const findFileStmt = db.prepare(
+            'SELECT id FROM file_cache WHERE session_id = ? AND file_path = ?'
+          );
+          const updateFileStmt = db.prepare(`
+            UPDATE file_cache
+            SET content = ?, hash = ?, size = ?, last_read = ?, updated_at = CURRENT_TIMESTAMP
+            WHERE id = ?
           `);
 
           let skippedFiles = 0;
+          let validFiles = 0;
           const filesByPath = new Map<string, any>();
           const fileOldIdsByPath = new Map<string, string[]>();
           for (const file of fileCacheEntries) {
@@ -2069,6 +2121,7 @@ Files: ${stats.files}`) + sizeWarning,
               skippedFiles++;
               continue;
             }
+            validFiles++;
             filesByPath.set(file.file_path, file);
             const oldIds = fileOldIdsByPath.get(file.file_path) ?? [];
             if (typeof file.id === 'string') {
@@ -2076,27 +2129,42 @@ Files: ${stats.files}`) + sizeWarning,
             }
             fileOldIdsByPath.set(file.file_path, oldIds);
           }
+          const collapsedFiles = validFiles - filesByPath.size;
 
           let fileCount = 0;
           for (const [filePath, file] of filesByPath) {
-            const newFileId = uuidv4();
-            for (const oldId of fileOldIdsByPath.get(filePath) ?? []) {
-              fileIdMap.set(oldId, newFileId);
-            }
             const content = file.content ?? null;
-            fileStmt.run(
-              newFileId,
-              targetSessionId,
-              file.file_path,
-              content,
-              typeof file.hash === 'string' ? file.hash : null,
+            const hash = typeof file.hash === 'string' ? file.hash : null;
+            const size =
               typeof file.size === 'number' && file.size >= 0
                 ? file.size
                 : typeof content === 'string'
                   ? calculateSize(content)
-                  : 0,
-              typeof file.last_read === 'string' ? file.last_read : null
-            );
+                  : 0;
+            const lastRead = typeof file.last_read === 'string' ? file.last_read : null;
+
+            const existing = merged
+              ? (findFileStmt.get(targetSessionId, filePath) as { id: string } | undefined)
+              : undefined;
+            let targetFileId: string;
+            if (existing) {
+              targetFileId = existing.id;
+              updateFileStmt.run(content, hash, size, lastRead, targetFileId);
+            } else {
+              targetFileId = uuidv4();
+              insertFileStmt.run(
+                targetFileId,
+                targetSessionId,
+                filePath,
+                content,
+                hash,
+                size,
+                lastRead
+              );
+            }
+            for (const oldId of fileOldIdsByPath.get(filePath) ?? []) {
+              fileIdMap.set(oldId, targetFileId);
+            }
             fileCount++;
           }
 
@@ -2199,6 +2267,8 @@ Files: ${stats.files}`) + sizeWarning,
             skippedCheckpoints,
             checkpointLinkCount,
             droppedCheckpointLinks,
+            collapsedItems,
+            collapsedFiles,
           };
         });
 
@@ -2211,8 +2281,8 @@ Files: ${stats.files}`) + sizeWarning,
         const lines = [
           'Import successful!',
           `Session: ${result.targetSessionId.substring(0, 8)}`,
-          `Context items: ${result.itemCount}${result.skippedItems ? ` (skipped ${result.skippedItems} malformed)` : ''}`,
-          `Files: ${result.fileCount}${result.skippedFiles ? ` (skipped ${result.skippedFiles} malformed)` : ''}`,
+          `Context items: ${result.itemCount}${result.skippedItems ? ` (skipped ${result.skippedItems} malformed)` : ''}${result.collapsedItems ? ` (collapsed ${result.collapsedItems} duplicate-key)` : ''}`,
+          `Files: ${result.fileCount}${result.skippedFiles ? ` (skipped ${result.skippedFiles} malformed)` : ''}${result.collapsedFiles ? ` (collapsed ${result.collapsedFiles} duplicate-path)` : ''}`,
           `Mode: ${result.createdNew ? 'New session' : 'Merged'}`,
         ];
         // Report checkpoints: restored for 0.5.0+ exports, or flagged as not
@@ -2231,7 +2301,7 @@ Files: ${stats.files}`) + sizeWarning,
           }
         } else if (checkpointEntries.length > 0) {
           lines.push(
-            `Checkpoints in file: ${checkpointEntries.length} (not imported — re-export with v0.5.0+ to include them)`
+            `Checkpoints in file: ${checkpointEntries.length} (not imported — this export predates checkpoint support and does not carry the item/file links)`
           );
         }
         // Warn when the caller asked to merge but there was no active session.


### PR DESCRIPTION
## Summary

Closes #37 (follow-up to #36). Makes checkpoints survive a `context_export` → `context_import` round trip.

Previously the export carried the bare `checkpoints` rows but **not** the `checkpoint_items` / `checkpoint_files` join rows, and import restored neither — so a re-imported session silently lost its checkpoints. (PR #36 made that loss explicit with a "not imported" note; this PR actually restores them.)

## Changes

**Export (`context_export`)**
- Bumped the export format to **`0.5.0`** and added `checkpointItems` and `checkpointFiles` to the payload (joined to the session's checkpoints).
- Tool description now states checkpoints + their links are included.

**Import (`context_import`)**
- Restores checkpoints inside the existing atomic transaction. Builds old→new id maps for `context_items` and `file_cache` as they're imported, then rewires each checkpoint's `checkpoint_items` / `checkpoint_files` foreign keys onto the freshly-generated ids.
- Each checkpoint gets a fresh id; malformed checkpoints are skipped; links pointing at a skipped/absent row are dropped (never abort the import).
- Summary now reports `Checkpoints: N (skipped M malformed), links restored: K`.
- **Backward compatible:** a pre-`0.5.0` export (no join-row arrays) imports cleanly and reports `Checkpoints in file: N (not imported — re-export with v0.5.0+ to include them)`.
- The #36 entry-count cap now also bounds the checkpoint and join-row arrays.

## Acceptance criteria (from #37)

- [x] Export + re-import reproduces checkpoints **and** their linked context items (and files).
- [x] Import summary reports the number of checkpoints restored.
- [x] Pre-change exports import without error and report checkpoints as not imported.
- [x] All shape/size/entry-count guards from #36 still apply.

## Testing

New E2E suite `src/__tests__/e2e/checkpoint-round-trip.test.ts` (spawns the real server over stdio):
- Full round trip: 2 items + 1 cached file + a checkpoint → export → import → `links restored: 3`, then `context_restore_checkpoint` reproduces `Context items: 2`, `Files: 1`.
- Legacy `0.4.0` export → imports cleanly, checkpoints reported as not imported.
- Dangling link (references a missing item id) → checkpoint imports, only the valid link is restored.

Full suite: **1234 tests pass**; lint/format/build clean; pre-commit hooks green.


## Review & hardening (in this PR)

Ran the full `/review:ts-enhanced-review` (team + adversarial rounds) and addressed the Claude review-bot suggestions — all fixes are in this PR:
- Fixed a merge-mode `INSERT OR REPLACE` cascade that could delete a pre-existing checkpoint's links (now UPDATE-in-place, preserving the row id) — with a regression test.
- Fixed a round-trip test false-pass (import now runs on a clean instance), dedupe by key/path to prevent id-map stranding, restore `file_cache.size`, and surface collapsed/dropped-link counts.
- Extracted a typed `restoreImportedCheckpoints()` helper.
- E2E suite is part of `npm test` (CI on Node 20/22/24): **1235 tests pass**.

## Release (part of this PR)

This is a backward-compatible feature, so it ships as a **minor** bump:
- `package.json` / lock bumped to **0.14.0**
- CHANGELOG notes finalized under `## [0.14.0]`
- Server reports `0.14.0` at runtime (read from `package.json`; verified by an e2e test)

Release is tag-triggered: after merge, push `v0.14.0` to publish to npm via `npm-publish.yml`.
